### PR TITLE
Fully remove obsolete model-url-template config

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -35,7 +35,6 @@ class JujuControllerCharm(CharmBase):
             return
         for relation in self.model.relations['dashboard']:
             relation.data[self.app]['controller-url'] = self.config['controller-url']
-            relation.data[self.app]['model-url-template'] = self.config['model-url-template']
             relation.data[self.app]['identity-provider-url'] = self.config['identity-provider-url']
             relation.data[self.app]['is-juju'] = str(self.config['is-juju'])
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -14,7 +14,6 @@ class TestCharm(unittest.TestCase):
         harness.begin()
         harness.set_leader(True)
         harness.update_config({"controller-url": "wss://controller/api"})
-        harness.update_config({"model-url-template": "wss://controller/model/${modelUUID}/api"})
         harness.update_config({"identity-provider-url": ""})
         harness.update_config({"is-juju": "true"})
         relation_id = harness.add_relation('dashboard', 'juju-dashboard')
@@ -22,6 +21,5 @@ class TestCharm(unittest.TestCase):
 
         data = harness.get_relation_data(relation_id, 'juju-controller')
         self.assertEqual(data["controller-url"], "wss://controller/api")
-        self.assertEqual(data["model-url-template"], "wss://controller/model/${modelUUID}/api")
         self.assertEqual(data["is-juju"], "true")
         self.assertEqual(data.get("identity-provider-url"), None)


### PR DESCRIPTION
model-url-template was removed from config but not from the hook code.
This fixes that omission.