### PR TITLE
Fix for the website relation.

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,6 +9,13 @@ bases:
           architectures: ["amd64"]
       run-on:
         - name: ubuntu
+          channel: "22.04"
+          architectures: 
+              - amd64
+              - aarch64
+              - arm64
+              - s390x
+        - name: ubuntu
           channel: "20.04"
           architectures: 
               - amd64

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,13 +4,13 @@
 
 import logging
 import os
-import yaml
 
-from charmhelpers.core import hookenv
+import yaml
+# from charmhelpers.core import hookenv
 from ops.charm import CharmBase
+from ops.framework import StoredState
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus
-from ops.framework import StoredState
 
 logger = logging.getLogger(__name__)
 
@@ -55,13 +55,15 @@ class JujuControllerCharm(CharmBase):
             self.unit.status = BlockedStatus('machine does not appear to be a controller')
             return
 
-        ingress_address = hookenv.ingress_address(event.relation.id, hookenv.local_unit())
-
-        event.relation.data[self.unit].update({
-            'hostname': ingress_address,
-            'private-address': ingress_address,
-            'port': str(port)
-        })
+        address = None
+        binding = self.model.get_binding(event.relation)
+        if binding:
+            address = binding.network.ingress_address
+            event.relation.data[self.unit].update({
+                'hostname': address,
+                'private-address': address,
+                'port': str(port)
+            })
 
 
 def api_port():

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -3,11 +3,10 @@
 
 import os
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
-from ops.testing import Harness
 from charm import JujuControllerCharm
-
+from ops.testing import Harness
 
 agent_conf = '''
 apiport: 17070
@@ -35,10 +34,11 @@ class TestCharm(unittest.TestCase):
         "JUJU_MACHINE_ID": "machine-0",
         "JUJU_UNIT_NAME": "controller/0"
     })
-    @patch("charmhelpers.core.hookenv.ingress_address")
+    @patch("ops.model.Model.get_binding")
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
     def test_website_relation_joined(self, open, ingress_address):
-        ingress_address.return_value = "192.168.1.17"
+        ingress_address.return_value = mockBinding("192.168.1.17")
+
         harness = Harness(JujuControllerCharm)
         self.addCleanup(harness.cleanup)
         harness.begin()
@@ -49,3 +49,13 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(data["hostname"], "192.168.1.17")
         self.assertEqual(data["private-address"], "192.168.1.17")
         self.assertEqual(data["port"], '17070')
+
+
+class mockBinding:
+    def __init__(self, address):
+        self.network = mockNetwork(address)
+
+
+class mockNetwork:
+    def __init__(self, address):
+        self.ingress_address = address


### PR DESCRIPTION
addresses #7 

- changes the way we get the private address of the unit.
- adds 22.04 for the "run-on" in the charmcraft.yaml