### PR TITLE
Update README and add dev guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Development guide
+
+You will need to have Python 3 and Charmcraft installed.
+```
+sudo snap install charmcraft --classic
+```
+
+## Setting up the environment
+
+Create and activate a virtualenv with the development requirements:
+
+    virtualenv -p python3 venv
+    source venv/bin/activate
+    pip install -r requirements-dev.txt
+
+## Testing
+
+The Python operator framework includes a very nice harness for testing
+operator behaviour without full deployment. Just `run_tests`:
+
+    ./run_tests
+
+## Deploying
+
+Before you deploy your modified controller charm, you will need to pack it using Charmcraft:
+```console
+$ charmcraft pack
+...
+Charms packed:
+    juju-controller_[...].charm
+```
+
+If deploying on LXD, you can bootstrap Juju using the `--controller-charm-path` flag, and providing the path to your packed charm.
+```console
+$ juju bootstrap lxd c --controller-charm-path=[path/to/packed/charm]
+```
+
+If deploying on k8s, you need to upload the charm to Charmhub first. Register a new charm name for testing:
+```console
+$ charmcraft register [new-name]
+```
+and upload the modified charm under this name:
+```console
+$ charmcraft upload *.charm --name [new-name] --release latest/stable
+Revision 1 of [new-name] created
+Revision released to latest/stable
+```
+
+Then, you can bootstrap a new k8s controller, providing the Charmhub name and channel:
+```console
+$ juju bootstrap microk8s c \
+--controller-charm-path=[new-name]
+--controller-charm-channel=latest/stable
+```
+
+## Releasing
+
+To release a new version of the controller charm, first pack the charm as above:
+```console
+$ charmcraft pack
+...
+Charms packed:
+    juju-controller_[...].charm
+```
+
+Then, upload under the name `juju-controller`:
+```console
+$ charmcraft upload *.charm --name juju-controller
+Revision [XX] of 'juju-controller' created
+```
+
+Finally, release it to the relevant channels. Along with a `latest` track, we maintain a track for every minor version of Juju, e.g. `3.0`, `3.1`, etc.
+```console
+$ charmcraft release juju-controller --revision [XX] --channel latest/stable --channel 3.0/stable
+Revision [XX] of charm 'juju-controller' released to latest/stable, 3.0/stable
+```
+
+You can also do the upload and release in a single step if you'd like:
+```console
+$ charmcraft upload *.charm --name juju-controller --release latest/stable --release 3.0/stable
+Revision [XX] of 'juju-controller' created
+Revision [XX] of charm 'juju-controller' released to latest/stable, 3.0/stable
+```

--- a/README.md
+++ b/README.md
@@ -2,23 +2,36 @@
 
 ## Description
 
-The Juju controller hosts and manages Juju models.
+The Juju controller charm allows charms to interact with the Juju controller
+via integrations. This charm is automatically deployed in the `controller`
+model of every controller for Juju 3.0 or later.
 
 ## Usage
 
-The controller provides an endpoint to integrate with a dashboard.
+The controller charm currently supports integrations with
+[`juju-dashboard`](https://charmhub.io/juju-dashboard) and
+[`haproxy`](https://charmhub.io/haproxy).
 
-## Developing
+You can deploy the Juju Dashboard in the `controller` model:
+```console
+$ juju switch controller
+$ juju deploy juju-dashboard --channel beta
+$ juju integrate controller juju-dashboard
+```
 
-Create and activate a virtualenv with the development requirements:
+or you can deploy it in its own model, and connect to the controller charm via
+a cross-model integration:
+```console
+$ juju add-model dashboard
+$ juju deploy juju-dashboard --channel beta
+$ juju offer juju-dashboard:controller
+Application "juju-dashboard" endpoints [controller] available at "admin/dashboard.juju-dashboard"
+$ juju switch controller
+$ juju integrate controller admin/dashboard.juju-dashboard
+```
 
-    virtualenv -p python3 venv
-    source venv/bin/activate
-    pip install -r requirements-dev.txt
-
-## Testing
-
-The Python operator framework includes a very nice harness for testing
-operator behaviour without full deployment. Just `run_tests`:
-
-    ./run_tests
+Then, run
+```
+juju dashboard --browser
+```
+and log in using the printed credentials.


### PR DESCRIPTION
As stated in the [charm docs](https://juju.is/docs/sdk/charm-documentation):
> Your README should **not** include developer-specific instructions.

I have removed the testing/developing instructions from README.md, and instead put them in a new file CONTRIBUTING.md.

I also rewrote/expanded the README to include a full example of how to integrate the controller charm with Juju Dashboard.

Finally, I added detailed instructions to CONTRIBUTING.md around deploying and releasing the controller charm.