### PR TITLE
Set relation data only if leader

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -36,13 +36,12 @@ class JujuControllerCharm(CharmBase):
 
     def _on_dashboard_relation_joined(self, event):
         logger.info("got a new dashboard relation: %r", event)
-
-        event.relation.data[self.app].update({
-            'controller-url': self.config['controller-url'],
-            'identity-provider-url': self.config['identity-provider-url'],
-            'is-juju': str(self.config['is-juju']),
-        })
-
+        if self.unit.is_leader():
+            event.relation.data[self.app].update({
+                'controller-url': self.config['controller-url'],
+                'identity-provider-url': self.config['identity-provider-url'],
+                'is-juju': str(self.config['is-juju']),
+            })
         # TODO: do we need to poke something on the controller so that the `juju
         # dashboard` command will work?
 
@@ -59,11 +58,12 @@ class JujuControllerCharm(CharmBase):
         binding = self.model.get_binding(event.relation)
         if binding:
             address = binding.network.ingress_address
-            event.relation.data[self.unit].update({
-                'hostname': address,
-                'private-address': address,
-                'port': str(port)
-            })
+            if self.unit.is_leader():
+                event.relation.data[self.unit].update({
+                    'hostname': str(address),
+                    'private-address': str(address),
+                    'port': str(port)
+                })
 
 
 def api_port():


### PR DESCRIPTION
We had a bug when HA was enabled (so multiple controller units) and a relation was connected. The non-leader units would also try to set the relation data, resulting in the error:
```
unit-controller-2: 09:17:32 ERROR unit.controller/2.juju-log dashboard:3: Uncaught exception while in charm code:
...
    raise RelationDataAccessError(
ops.model.RelationDataAccessError: controller/2 is not leader and cannot write application data.
```

To fix this, check if the current unit is leader before setting relation data.

We're also now converting IP addresses to `str` before setting relation data, to fix a type error that was coming up when relating to `haproxy`.