### PR TITLE
assume juju >= 3.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 # Copyright 2021 Canonical Ltd.
 # Licensed under the GPLv3, see LICENSE file for details.
 name: juju-controller
+assumes:
+- juju >= 3.0
 description: |
   The Juju controller charm is used to expose various pieces
   of functionality of a Juju controller.


### PR DESCRIPTION
Add
```yaml
assumes:
- juju >= 3.0
```
to `metadata.yaml`, so that the controller charm can only be deployed on Juju 3.0+. It doesn't make sense on Juju 2.9 or earlier.

## QA steps

Try to deploy on Juju 2.9:
```console
$ juju2.9 deploy juju-controller.charm
Located local charm "juju-controller", revision 0
Deploying "juju-controller" from local charm "juju-controller", revision 0 on jammy
ERROR Charm feature requirements cannot be met:
  - charm requires feature "juju" (version >= 3.0.0) but model currently supports version 2.9.37
```

GitHub checks will confirm it can still be deployed on Juju 3.0.0.