### PR TITLE
Update build_charms_with_cache.yaml to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
   build:
     name: Build charms
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
     with:
       artifact-name: charm-packed
 


### PR DESCRIPTION
`v2` is currently the latest version of canonical/data-platform-workflows

Old major versions do **not** receive backported bug fixes (e.g. [this one](https://github.com/canonical/data-platform-workflows/releases/tag/v2.0.3))

There were no breaking changes to build_charms_with_cache.yaml in v2 ([changelog](https://github.com/canonical/data-platform-workflows/releases/tag/v2.0.0))—a breaking change was made to a different workflow, but all workflows in the repository share the same version number