### PR TITLE
Add Charmhub docs link to metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,6 +8,7 @@ description: |
   of functionality of a Juju controller.
 summary: |
   The Juju controller.
+docs: https://discourse.charmhub.io/t/10534
 provides:
   dashboard:
     interface: juju-dashboard


### PR DESCRIPTION
Following the guide [here](https://juju.is/docs/sdk/add-docs-to-your-charmhub-page), this should allow the docs to display correctly on the [Charmhub page](https://charmhub.io/juju-controller).