### PR TITLE
[ci] add job to release to edge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,47 @@ jobs:
         juju status
 
     # TODO: test integration with dashboard / ha-proxy
+
+  release:
+    name: "Release to edge"
+    runs-on: ubuntu-latest
+    needs: [build, bootstrap]
+    if: github.event_name == 'push'
+
+    steps:
+    - name: Download packed charm
+      id: download
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ needs.build.outputs.artifact-name }}
+
+    - name: Select Charmhub channel
+      id: channel
+      shell: bash
+      run: |
+        set -x
+        case ${{ github.ref_name }} in
+          3.* | 4.*)
+            TRACK="${{ github.ref_name }}"
+            ;;
+          master)
+            TRACK="latest"
+            ;;
+        esac
+        echo "track=$TRACK" >> "$GITHUB_OUTPUT"
+        
+        if [[ -z $CHANNEL ]]; then
+          echo "upload=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "upload=true" >> "$GITHUB_OUTPUT"
+        fi
+        
+
+    - name: Upload to Charmhub
+      if: steps.channel.outputs.upload == 'true'
+      env:
+        CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
+      run: |
+        sudo snap install charmcraft --classic
+        charmcraft upload ${{ steps.download.outputs.download-path }}/*.charm \
+          --release ${{ steps.channel.outputs.track }}/edge


### PR DESCRIPTION
When new commits are added to a branch, this job will release the charm to the corresponding edge channel, assuming CI passes.

The mapping of Git branch -> Charmhub channel is as follows:
- if `$GIT_BRANCH_NAME` is `3.*` or `4.*`, the channel is `$GIT_BRANCH_NAME/edge`
- if `$GIT_BRANCH_NAME` is `master`, the channel is `latest/edge`

Any other branches won't be released to Charmhub.

Currently, this mapping looks like
```
   3.1 -> 3.1/edge
   3.2 -> 3.2/edge
   3.3 -> 3.3/edge
master -> latest/edge
```