### PR TITLE
Use Juju 3.1 for GH workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
     - name: Install Juju
       run: |
-        sudo snap install juju --channel 3.0/stable
+        sudo snap install juju --channel 3.1/stable
 
     - name: Bootstrap on LXD
       if: matrix.cloud == 'lxd'


### PR DESCRIPTION
This updates the CI workflow to install Juju 3.1.