### PR TITLE
Merge 3.1 into 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
     - name: Install Juju
       run: |
-        sudo snap install juju --channel 3.1/stable
+        sudo snap install juju --channel 3.2/stable
 
     - name: Bootstrap on LXD
       if: matrix.cloud == 'lxd'


### PR DESCRIPTION
Merges 3.1 into 3.2 with #30, and updates the Juju version to 3.2, which is the one compatible with this charm.