### PR TITLE
ci: install Juju from 3.3/beta channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
     - name: Install Juju
       run: |
-        sudo snap install juju --channel 3.2/stable
+        sudo snap install juju --channel 3.3/beta
 
     - name: Bootstrap on LXD
       if: matrix.cloud == 'lxd'


### PR DESCRIPTION
Use the correct version of Juju in CI. `beta` is the most stable track available at the moment.