### PR TITLE
set_leader in test_website_relation_joined

### DIFF
--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -42,6 +42,7 @@ class TestCharm(unittest.TestCase):
         harness = Harness(JujuControllerCharm)
         self.addCleanup(harness.cleanup)
         harness.begin()
+        harness.set_leader()
         relation_id = harness.add_relation('website', 'haproxy')
         harness.add_relation_unit(relation_id, 'haproxy/0')
 


### PR DESCRIPTION
The `test_website_relation_joined` unit test was failing because I forgot to update the test in #14. The `_on_website_relation_joined` handler only adds the relation data if it's the leader unit.

The fix is easy - call `harness.set_leader()` before adding the relation.

## QA steps

```
virtualenv -p python3 venv
source venv/bin/activate
pip install -r requirements-dev.txt
./run_tests
```