### PR TITLE
parse controller API port from apiaddresses in agent.conf

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -11,6 +11,6 @@ if [ -n "$PYTHONPATH" ]; then
 fi
 export PYTHONPATH="src:lib$PYTHONPATH"
 
-flake8
 coverage run --source=src -m unittest -v "$@"
 coverage report -m
+flake8


### PR DESCRIPTION
Sometimes (on k8s), the `apiport` key is not defined inside the unit's `agent.conf`. In this case, we need to parse the value given in the `apiaddresses` key, which has the form
```
apiaddresses:
- localhost:17070
```

Change the `api_port` method so that we're parsing the `apiaddresses` agent.conf key, instead of relying on `apiport`. If the key can't be found, then the method raises an `AgentConfException`, which is caught in the event handler and the status is set to 'error'.

Add unit tests to cover all this.

As a drive-by, move flake8 to the end of the `run_tests` script, so that unit tests are always run, even if the linting doesn't pass.