### PR TITLE
Add dbcluster peer relation

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,3 +16,6 @@ provides:
     interface: http
   metrics-endpoint:
     interface: prometheus_scrape
+peers:
+  dbcluster:
+    interface: dbcluster


### PR DESCRIPTION
This adds a new peer relation to the controller charm: `dbcluster`.

The binding for this relation will ultimately replace the Juju controller configuration article, `juju-ha-space`. Accordingly, the charm ensures that the current bound space yields a unique ingress address that gets set in relation data. If the address is not unique, the charm enters the blocked state.

Further work will follow that will write a charm-sourced configuration file to disk that will be an analogue for agent configuration.