### PR TITLE
[JUJU-5140] Maintain a list of all database bind addresses

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class JujuControllerCharm(CharmBase):
+    DB_BIND_ADDR_KEY = 'db-bind-address'
     _stored = StoredState()
 
     def __init__(self, *args):
@@ -32,8 +33,7 @@ class JujuControllerCharm(CharmBase):
         self.framework.observe(
             self.on.website_relation_joined, self._on_website_relation_joined)
 
-        self._stored.set_default(db_bind_address='')
-        self._stored.set_default(last_bind_addresses=[])
+        self._stored.set_default(db_bind_address='', last_bind_addresses=[], all_bind_addresses=[])
         self.framework.observe(
             self.on.dbcluster_relation_changed, self._on_dbcluster_relation_changed)
 
@@ -53,16 +53,16 @@ class JujuControllerCharm(CharmBase):
             self.api_port()
         except AgentConfException as e:
             event.add_status(ErrorStatus(
-                f"cannot read controller API port from agent configuration: {e}"))
+                f'cannot read controller API port from agent configuration: {e}'))
 
         event.add_status(ActiveStatus())
 
     def _on_config_changed(self, _):
         controller_url = self.config['controller-url']
-        logger.info("got a new controller-url: %r", controller_url)
+        logger.info('got a new controller-url: %r', controller_url)
 
     def _on_dashboard_relation_joined(self, event):
-        logger.info("got a new dashboard relation: %r", event)
+        logger.info('got a new dashboard relation: %r', event)
         if self.unit.is_leader():
             event.relation.data[self.app].update({
                 'controller-url': self.config['controller-url'],
@@ -79,7 +79,7 @@ class JujuControllerCharm(CharmBase):
         try:
             api_port = self.api_port()
         except AgentConfException as e:
-            logger.error("cannot read controller API port from agent configuration: {}", e)
+            logger.error('cannot read controller API port from agent configuration: {}', e)
             return
 
         address = None
@@ -102,7 +102,7 @@ class JujuControllerCharm(CharmBase):
         try:
             api_port = self.api_port()
         except AgentConfException as e:
-            logger.error("cannot read controller API port from agent configuration: {}", e)
+            logger.error('cannot read controller API port from agent configuration: {}', e)
             return
 
         metrics_endpoint = MetricsEndpointProvider(
@@ -132,20 +132,46 @@ class JujuControllerCharm(CharmBase):
         self.control_socket.remove_metrics_user(username)
 
     def _on_dbcluster_relation_changed(self, event):
-        ips = self.model.get_binding(event.relation).network.ingress_addresses
+        """Ensure that a bind address for Dqlite is set in relation data,
+        if we can determine a unique one from the relation's bound space.
+        If we are the leader, aggregate the bind addresses for all the peers,
+        and ensure the result is set in the application data bag.
+        """
+        self._ensure_db_bind_address(event)
+
+        if self.unit.is_leader():
+            # The event only has *other* units so include this
+            # unit's bind address if we have managed to set it.
+            ip = self._stored.db_bind_address
+            all_bind_addresses = [ip] if ip else []
+
+            for unit in event.relation.units:
+                unit_data = event.relation.data[unit]
+                if self.DB_BIND_ADDR_KEY in unit_data:
+                    all_bind_addresses.append(unit_data[self.DB_BIND_ADDR_KEY])
+
+            all_bind_addresses.sort()
+            if self._stored.all_bind_addresses == all_bind_addresses:
+                return
+
+            event.relation.data[self.app]['db-bind-addresses'] = ','.join(all_bind_addresses)
+            self._stored.all_bind_addresses = all_bind_addresses
+
+    def _ensure_db_bind_address(self, event):
+        ips = [str(ip) for ip in self.model.get_binding(event.relation).network.ingress_addresses]
         self._stored.last_bind_addresses = ips
 
         if len(ips) > 1:
             logger.error(
-                'multiple possible DB bind addresses; set a suitable bcluster network binding')
+                'multiple possible DB bind addresses; set a suitable cluster network binding')
             return
 
-        ip = str(ips[0])
+        ip = ips[0]
         if self._stored.db_bind_address == ip:
             return
 
+        event.relation.data[self.unit].update({self.DB_BIND_ADDR_KEY: ip})
         self._stored.db_bind_address = ip
-        event.relation.data[self.unit].update({'db-bind-address': ip})
 
     def api_port(self) -> str:
         """Return the port on which the controller API server is listening."""
@@ -157,7 +183,7 @@ class JujuControllerCharm(CharmBase):
 
         parsed_url = urllib.parse.urlsplit('//' + api_addresses[0])
         if not parsed_url.port:
-            raise AgentConfException("API address does not include port")
+            raise AgentConfException('API address does not include port')
         return parsed_url.port
 
     def ca_cert(self) -> str:

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -2,6 +2,7 @@
 # Licensed under the GPLv3, see LICENSE file for details.
 
 import ipaddress
+import json
 import os
 import unittest
 from charm import JujuControllerCharm, AgentConfException
@@ -170,7 +171,8 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(unit_data['db-bind-address'], '192.168.1.17')
 
         app_data = harness.get_relation_data(relation_id, 'juju-controller')
-        self.assertEqual(app_data['db-bind-addresses'], '192.168.1.100,192.168.1.17')
+        exp = {"juju-controller/0": "192.168.1.17", "juju-controller/1": "192.168.1.100"}
+        self.assertEqual(json.loads(app_data['db-bind-addresses']), exp)
 
         harness.evaluate_status()
         self.assertIsInstance(harness.charm.unit.status, ActiveStatus)


### PR DESCRIPTION
We want to have the controller charm maintain a new configuration file, separate from the Juju-generated agent configuration.

In similar fashion to how API addresses are maintained in the agent configuration file, we will maintain the Dqlite bind addresses in the new file.

Here, we ensure that each unit has access to the known bind addresses via the application data bag for the `dbcluster` relation.

The leader unit is responsible for setting the data when other units change their own bind addresses in unit data bags.

The new behaviour can be verified via these steps:
- `charmcraft pack` this charm.
- Bootstrap a new LXD controller using `--controller-charm-path <path-to-packed-artefact>`.
- `juju enable-ha`.
- Once settled, `juju show-unit -m controller controller/0` will a show JSON dictionary of unit IP addresses for `db-bind-addresses`.
```
  relation-info:
  - relation-id: 0
    endpoint: dbcluster
    related-endpoint: dbcluster
    application-data:
      db-bind-addresses: '{"controller/0": "10.246.27.57", "controller/2": "10.246.27.62",
        "controller/1": "10.246.27.127"}'
```