### PR TITLE
Send SIGHUP to controller jujud process when configuration file changes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -18,7 +18,7 @@ from ops.charm import CharmBase, CollectStatusEvent
 from ops.framework import StoredState
 from ops.charm import InstallEvent, RelationJoinedEvent, RelationDepartedEvent
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, ErrorStatus, Relation
+from ops.model import ActiveStatus, BlockedStatus, Relation
 from pathlib import Path
 from typing import List
 
@@ -71,7 +71,7 @@ class JujuControllerCharm(CharmBase):
         try:
             self.api_port()
         except AgentConfException as e:
-            event.add_status(ErrorStatus(
+            event.add_status(BlockedStatus(
                 f'cannot read controller API port from agent configuration: {e}'))
 
         event.add_status(ActiveStatus())

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -157,8 +157,12 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         mock_get_binding.return_value = mockBinding(['192.168.1.17'])
 
+        # This is an example of how the jujud invocation looks on machines/VMs.
+        pgrep = ('666 /var/lib/juju/tools/machine-0/jujud machine '
+                 '--data-dir /var/lib/juju --machine-id 0 --debug')
+
         # First call is to get the controller service name; last is for its PID.
-        mock_check_out.side_effect = ['jujud-machine-0.service', '12345']
+        mock_check_out.side_effect = [pgrep, pgrep]
 
         harness.set_leader()
 
@@ -204,8 +208,12 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         mock_get_binding.return_value = mockBinding(['192.168.1.17'])
 
+        # This is an example of how the jujud invocation looks on K8s.
+        pgrep = ('12345 /var/lib/juju/tools/jujud machine --data-dir '
+                 '/var/lib/juju --controller-id 0 --log-to-stderr')
+
         # First call is to get the controller service name; last is for its PID.
-        mock_check_out.side_effect = ['jujud-machine-0.service', '12345']
+        mock_check_out.side_effect = [pgrep, pgrep]
 
         relation_id = harness.add_relation('dbcluster', harness.charm.app)
         harness.add_relation_unit(relation_id, 'juju-controller/1')

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -9,7 +9,7 @@ import unittest
 import yaml
 
 from charm import JujuControllerCharm, AgentConfException
-from ops.model import BlockedStatus, ActiveStatus, ErrorStatus
+from ops.model import BlockedStatus, ActiveStatus
 from ops.testing import Harness
 from unittest.mock import mock_open, patch
 
@@ -139,7 +139,7 @@ class TestCharm(unittest.TestCase):
 
         harness.add_relation('metrics-endpoint', 'prometheus-k8s')
         harness.evaluate_status()
-        self.assertIsInstance(harness.charm.unit.status, ErrorStatus)
+        self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf_ipv4)
     def test_apiaddresses_ipv4(self, _):

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -157,9 +157,8 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         mock_get_binding.return_value = mockBinding(['192.168.1.17'])
 
-        # First calls are to get the controller service name; last is for its PID.
-        mock_check_out.side_effect = [
-            'jujud-machine-0.service', 'jujud-machine-0.service', b'pid=12345']
+        # First call is to get the controller service name; last is for its PID.
+        mock_check_out.side_effect = ['jujud-machine-0.service', '12345']
 
         harness.set_leader()
 
@@ -205,9 +204,8 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         mock_get_binding.return_value = mockBinding(['192.168.1.17'])
 
-        # First calls are to get the controller service name; last is for its PID.
-        mock_check_out.side_effect = [
-            'jujud-machine-0.service', 'jujud-machine-0.service', b'pid=12345']
+        # First call is to get the controller service name; last is for its PID.
+        mock_check_out.side_effect = ['jujud-machine-0.service', '12345']
 
         relation_id = harness.add_relation('dbcluster', harness.charm.app)
         harness.add_relation_unit(relation_id, 'juju-controller/1')

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -162,7 +162,7 @@ class TestCharm(unittest.TestCase):
 
         # Have another unit enter the relation.
         # Its bind address should end up in the application data bindings list.
-        relation_id = harness.add_relation('dbcluster', harness.charm.app.name)
+        relation_id = harness.add_relation('dbcluster', harness.charm.app)
         harness.add_relation_unit(relation_id, 'juju-controller/1')
         self.harness.update_relation_data(
             relation_id, 'juju-controller/1', {'db-bind-address': '192.168.1.100'})
@@ -183,7 +183,7 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         binding.return_value = mockBinding(["192.168.1.17", "192.168.1.18"])
 
-        relation_id = harness.add_relation('dbcluster', harness.charm.app.name)
+        relation_id = harness.add_relation('dbcluster', harness.charm.app)
         harness.add_relation_unit(relation_id, 'juju-controller/1')
 
         self.harness.update_relation_data(


### PR DESCRIPTION
This patch does two things:
- We no longer assume that the identity of the controller itself is congruent with the controller unit ID. We now get this information from the running controller jujud process.
- When the controller configuration file is changed, we send a SIGHUP to the controller's process, which will be detected there, causing a reload of the new configuration.

To verify:
- `charmcraft pack` this charm.
- Bootstrap a new LXD controller using `--controller-charm-path <path-to-packed-artefact>`.
- `juju enable-ha`.
- Once all units have joined the relation, ssh to the controller machine and check _/var/lib/juju/agents/controller-0/agent.conf_. It should be populated along the lines of:
```
db-bind-addresses:
  controller/0: 10.246.27.181
  controller/1: 10.246.27.53
  controller/2: 10.246.27.12
```
- `juju debug-log -m controller --replay|grep SIGHUP` will indicate signals across the different controllers.

https://warthogs.atlassian.net/browse/JUJU-5306