### PR TITLE
Uses BlockedStatus instead of ErrorStatus

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,7 @@ from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.charm import RelationJoinedEvent, RelationDepartedEvent
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, ErrorStatus, Relation
+from ops.model import ActiveStatus, BlockedStatus, Relation
 from typing import List
 
 logger = logging.getLogger(__name__)
@@ -84,7 +84,8 @@ class JujuControllerCharm(CharmBase):
         try:
             api_port = self.api_port()
         except AgentConfException as e:
-            self.unit.status = ErrorStatus(f"can't read controller API port from agent.conf: {e}")
+            self.unit.status = BlockedStatus(
+                f"can't read controller API port from agent.conf: {e}")
             return
 
         metrics_endpoint = MetricsEndpointProvider(

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -4,7 +4,7 @@
 import os
 import unittest
 from charm import JujuControllerCharm, AgentConfException
-from ops import ErrorStatus
+from ops import BlockedStatus
 from ops.testing import Harness
 from unittest.mock import mock_open, patch
 
@@ -140,7 +140,7 @@ class TestCharm(unittest.TestCase):
         harness.begin()
 
         harness.add_relation('metrics-endpoint', 'prometheus-k8s')
-        self.assertEqual(harness.charm.unit.status, ErrorStatus(
+        self.assertEqual(harness.charm.unit.status, BlockedStatus(
             "can't read controller API port from agent.conf: agent.conf key 'apiaddresses' missing"
         ))
 


### PR DESCRIPTION
With the new version of Ops, setting `ErrorStatus` explicitly causes an error to be thrown.

Here we use `BlockedStatus` instead when we can't determine the API port from agent configuration.