### PR TITLE
Write controller config and signal the controller agent

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -3,12 +3,11 @@
 # Licensed under the GPLv3, see LICENSE file for details.
 
 import controlsocket
+import configchangesocket
 import json
 import logging
-import os
 import re
 import secrets
-import signal
 import subprocess
 import urllib.parse
 import yaml
@@ -50,8 +49,10 @@ class JujuControllerCharm(CharmBase):
         self.framework.observe(
             self.on.dbcluster_relation_changed, self._on_dbcluster_relation_changed)
 
-        self.control_socket = controlsocket.Client(
+        self.control_socket = controlsocket.ControlSocketClient(
             socket_path='/var/lib/juju/control.socket')
+        self.config_change_socket = configchangesocket.ConfigChangeSocketClient(
+            socket_path='/var/lib/juju/configchange.socket')
         self.framework.observe(
             self.on.metrics_endpoint_relation_created, self._on_metrics_endpoint_relation_created)
         self.framework.observe(
@@ -221,7 +222,7 @@ class JujuControllerCharm(CharmBase):
         with open(file_path, 'w') as conf_file:
             yaml.dump(conf, conf_file)
 
-        self._sighup_controller_process()
+        self._request_config_reload()
         self._stored.all_bind_addresses = bind_addresses
 
     def api_port(self) -> str:
@@ -265,10 +266,6 @@ class JujuControllerCharm(CharmBase):
         controller_id = match.group(1)
         return f'/var/lib/juju/agents/controller-{controller_id}/agent.conf'
 
-    def _sighup_controller_process(self):
-        """Determine the controller's jujud process ID, and signal it with SIGHUP."""
-        os.kill(self._get_controller_process()[0], signal.SIGHUP)
-
     def _get_controller_process(self):
         """Use pgrep to get the controller's jujud process ID and full command."""
 
@@ -283,6 +280,10 @@ class JujuControllerCharm(CharmBase):
 
         parts = lines[0].split(' ', 1)
         return (int(parts[0]), parts[1])
+
+    def _request_config_reload(self):
+        """Set reload request to the config reload socket"""
+        self.config_change_socket.reload_config()
 
 
 def metrics_username(relation: Relation) -> str:

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,7 +18,7 @@ from ops.charm import CharmBase, CollectStatusEvent
 from ops.framework import StoredState
 from ops.charm import InstallEvent, RelationJoinedEvent, RelationDepartedEvent
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, ErrorStatus, Relation
+from ops.model import ActiveStatus, BlockedStatus, Relation
 from pathlib import Path
 from typing import List
 
@@ -71,7 +71,7 @@ class JujuControllerCharm(CharmBase):
         try:
             self.api_port()
         except AgentConfException as e:
-            event.add_status(ErrorStatus(
+            event.add_status(BlockedStatus(
                 f'cannot read controller API port from agent configuration: {e}'))
 
         event.add_status(ActiveStatus())

--- a/src/configchangesocket.py
+++ b/src/configchangesocket.py
@@ -20,7 +20,7 @@ class ConfigChangeSocketClient(unixsocket.SocketClient):
 
     def reload_config(self):
         resp = self.request_raw(
-            method='GET',
+            method='POST',
             path='/reload',
         )
         logger.debug('result of reload request: %r', resp)

--- a/src/configchangesocket.py
+++ b/src/configchangesocket.py
@@ -18,9 +18,9 @@ class ConfigChangeSocketClient(unixsocket.SocketClient):
                  opener: Optional[urllib.request.OpenerDirector] = None):
         super().__init__(socket_path, opener=opener)
 
+    def get_controller_agent_id(self):
+        resp = self.request_raw(path='/agent-id', method='GET')
+        return resp.read().decode('utf-8')
+
     def reload_config(self):
-        resp = self.request_raw(
-            method='POST',
-            path='/reload',
-        )
-        logger.debug('result of reload request: %r', resp)
+        self.request_raw(path='/reload', method='POST')

--- a/src/configchangesocket.py
+++ b/src/configchangesocket.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# Licensed under the GPLv3, see LICENSE file for details.
+import urllib
+from typing import Optional
+
+import unixsocket
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigChangeSocketClient(unixsocket.SocketClient):
+    """
+    Client to the Juju config change socket.
+    """
+    def __init__(self, socket_path: str,
+                 opener: Optional[urllib.request.OpenerDirector] = None):
+        super().__init__(socket_path, opener=opener)
+
+    def reload_config(self):
+        resp = self.request_raw(
+            method='GET',
+            path='/reload',
+        )
+        logger.debug('result of reload request: %r', resp)

--- a/src/controlsocket.py
+++ b/src/controlsocket.py
@@ -1,136 +1,25 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # Licensed under the GPLv3, see LICENSE file for details.
+import urllib
+from typing import Optional
 
-import email.message
-import email.parser
-import http.client
-import json
+import unixsocket
 import logging
-import socket
-import sys
-import urllib.error
-import urllib.parse
-import urllib.request
-from typing import (
-    Any,
-    Dict,
-    Generator,
-    Literal,
-    Optional,
-    Union,
-)
 
 logger = logging.getLogger(__name__)
 
 
-class Client:
+class ControlSocketClient(unixsocket.SocketClient):
     """
-    Client to the Juju control socket.
-
-    Defaults to using a Unix socket at socket_path (which must be specified
-    unless a custom opener is provided).
-
-    Originally copy-pasted from ops.pebble.Client.
+    Client to Juju control socket.
     """
-
     def __init__(self, socket_path: str,
-                 opener: Optional[urllib.request.OpenerDirector] = None,
-                 base_url: str = 'http://localhost',
-                 timeout: float = 5.0):
-        if not isinstance(socket_path, str):
-            raise TypeError(f'`socket_path` should be a string, not: {type(socket_path)}')
-        if opener is None:
-            opener = self._get_default_opener(socket_path)
-        self.socket_path = socket_path
-        self.opener = opener
-        self.base_url = base_url
-        self.timeout = timeout
-
-    @classmethod
-    def _get_default_opener(cls, socket_path: str) -> urllib.request.OpenerDirector:
-        """Build the default opener to use for requests (HTTP over Unix socket)."""
-        opener = urllib.request.OpenerDirector()
-        opener.add_handler(_UnixSocketHandler(socket_path))
-        opener.add_handler(urllib.request.HTTPDefaultErrorHandler())
-        opener.add_handler(urllib.request.HTTPRedirectHandler())
-        opener.add_handler(urllib.request.HTTPErrorProcessor())
-        return opener
-
-    # we need to cast the return type depending on the request params
-    def _request(self,
-                 method: str,
-                 path: str,
-                 query: Optional[Dict[str, Any]] = None,
-                 body: Optional[Dict[str, Any]] = None
-                 ) -> Dict[str, Any]:
-        """Make a JSON request to the socket with the given HTTP method and path.
-
-        If query dict is provided, it is encoded and appended as a query string
-        to the URL. If body dict is provided, it is serialied as JSON and used
-        as the HTTP body (with Content-Type: "application/json"). The resulting
-        body is decoded from JSON.
-        """
-        headers = {'Accept': 'application/json'}
-        data = None
-        if body is not None:
-            data = json.dumps(body).encode('utf-8')
-            headers['Content-Type'] = 'application/json'
-
-        response = self._request_raw(method, path, query, headers, data)
-        self._ensure_content_type(response.headers, 'application/json')
-        raw_resp: Dict[str, Any] = json.loads(response.read())
-        return raw_resp
-
-    @staticmethod
-    def _ensure_content_type(headers: email.message.Message,
-                             expected: 'Literal["multipart/form-data", "application/json"]'):
-        """Parse Content-Type header from headers and ensure it's equal to expected.
-
-        Return a dict of any options in the header, e.g., {'boundary': ...}.
-        """
-        ctype = headers.get_content_type()
-        params = headers.get_params() or {}
-        options = {key: value for key, value in params if value}
-        if ctype != expected:
-            raise ProtocolError(f'expected Content-Type {expected!r}, got {ctype!r}')
-        return options
-
-    def _request_raw(
-        self, method: str, path: str,
-        query: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, Any]] = None,
-        data: Optional[Union[bytes, Generator[bytes, Any, Any]]] = None,
-    ) -> http.client.HTTPResponse:
-        """Make a request to the socket; return the raw HTTPResponse object."""
-        url = self.base_url + path
-        if query:
-            url = f"{url}?{urllib.parse.urlencode(query, doseq=True)}"
-
-        if headers is None:
-            headers = {}
-        request = urllib.request.Request(url, method=method, data=data, headers=headers)
-
-        try:
-            response = self.opener.open(request, timeout=self.timeout)
-        except urllib.error.HTTPError as e:
-            code = e.code
-            status = e.reason
-            try:
-                body: Dict[str, Any] = json.loads(e.read())
-                message: str = body['error']
-            except (OSError, ValueError, KeyError) as e2:
-                # Will only happen on read error or if the server sends invalid JSON.
-                body: Dict[str, Any] = {}
-                message = f'{type(e2).__name__} - {e2}'
-            raise APIError(body, code, status, message)
-        except urllib.error.URLError as e:
-            raise ConnectionError(e.reason)
-
-        return response
+                 opener: Optional[urllib.request.OpenerDirector] = None):
+        super().__init__(socket_path, opener=opener)
 
     def add_metrics_user(self, username: str, password: str):
-        resp = self._request(
+        resp = self.json_request(
             method='POST',
             path='/metrics-users',
             body={"username": username, "password": password},
@@ -138,92 +27,8 @@ class Client:
         logger.debug('result of add_metrics_user request: %r', resp)
 
     def remove_metrics_user(self, username: str):
-        resp = self._request(
+        resp = self.json_request(
             method='DELETE',
             path=f'/metrics-users/{username}',
         )
         logger.debug('result of remove_metrics_user request: %r', resp)
-
-
-class _NotProvidedFlag:
-    pass
-
-
-_not_provided = _NotProvidedFlag()
-
-
-class _UnixSocketConnection(http.client.HTTPConnection):
-    """Implementation of HTTPConnection that connects to a named Unix socket."""
-
-    def __init__(self, host: str, socket_path: str,
-                 timeout: Union[_NotProvidedFlag, float] = _not_provided):
-        if timeout is _not_provided:
-            super().__init__(host)
-        else:
-            assert isinstance(timeout, (int, float)), timeout  # type guard for pyright
-            super().__init__(host, timeout=timeout)
-        self.socket_path = socket_path
-
-    def connect(self):
-        """Override connect to use Unix socket (instead of TCP socket)."""
-        if not hasattr(socket, 'AF_UNIX'):
-            raise NotImplementedError(f'Unix sockets not supported on {sys.platform}')
-        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.sock.connect(self.socket_path)
-        if self.timeout is not _not_provided:
-            self.sock.settimeout(self.timeout)
-
-
-class _UnixSocketHandler(urllib.request.AbstractHTTPHandler):
-    """Implementation of HTTPHandler that uses a named Unix socket."""
-
-    def __init__(self, socket_path: str):
-        super().__init__()
-        self.socket_path = socket_path
-
-    def http_open(self, req: urllib.request.Request):
-        """Override http_open to use a Unix socket connection (instead of TCP)."""
-        return self.do_open(_UnixSocketConnection, req,  # type:ignore
-                            socket_path=self.socket_path)
-
-
-class Error(Exception):
-    """Base class of most errors raised by the client."""
-
-    def __repr__(self):
-        return f'<{type(self).__module__}.{type(self).__name__} {self.args}>'
-
-
-class ProtocolError(Error):
-    """Raised when there's a higher-level protocol error talking to the socket."""
-
-
-class ConnectionError(Error):
-    """Raised when the client can't connect to the socket."""
-
-
-class APIError(Error):
-    """Raised when an HTTP API error occurs talking to the Pebble server."""
-
-    body: Dict[str, Any]
-    """Body of the HTTP response, parsed as JSON."""
-
-    code: int
-    """HTTP status code."""
-
-    status: str
-    """HTTP status string (reason)."""
-
-    message: str
-    """Human-readable error message from the API."""
-
-    def __init__(self, body: Dict[str, Any], code: int, status: str, message: str):
-        """This shouldn't be instantiated directly."""
-        super().__init__(message)  # Makes str(e) return message
-        self.body = body
-        self.code = code
-        self.status = status
-        self.message = message
-
-    def __repr__(self):
-        return f'APIError({self.body!r}, {self.code!r}, {self.status!r}, {self.message!r})'

--- a/src/unixsocket.py
+++ b/src/unixsocket.py
@@ -1,0 +1,205 @@
+import email.message
+import email.parser
+import http.client
+import json
+import socket
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Literal,
+    Optional,
+    Union,
+)
+
+
+class SocketClient:
+    """
+    Defaults to using a Unix socket at socket_path (which must be specified
+    unless a custom opener is provided).
+
+    Originally copy-pasted from ops.pebble.Client.
+    """
+
+    def __init__(self, socket_path: str,
+                 opener: Optional[urllib.request.OpenerDirector] = None,
+                 base_url: str = 'http://localhost',
+                 timeout: float = 5.0):
+        if not isinstance(socket_path, str):
+            raise TypeError(f'`socket_path` should be a string, not: {type(socket_path)}')
+        if opener is None:
+            opener = self._get_default_opener(socket_path)
+        self.socket_path = socket_path
+        self.opener = opener
+        self.base_url = base_url
+        self.timeout = timeout
+
+    @classmethod
+    def _get_default_opener(cls, socket_path: str) -> urllib.request.OpenerDirector:
+        """Build the default opener to use for requests (HTTP over Unix socket)."""
+        opener = urllib.request.OpenerDirector()
+        opener.add_handler(_UnixSocketHandler(socket_path))
+        opener.add_handler(urllib.request.HTTPDefaultErrorHandler())
+        opener.add_handler(urllib.request.HTTPRedirectHandler())
+        opener.add_handler(urllib.request.HTTPErrorProcessor())
+        return opener
+
+    # we need to cast the return type depending on the request params
+    def json_request(self,
+                     method: str,
+                     path: str,
+                     query: Optional[Dict[str, Any]] = None,
+                     body: Optional[Dict[str, Any]] = None
+                     ) -> Dict[str, Any]:
+        """Make a JSON request to the socket with the given HTTP method and path.
+
+        If query dict is provided, it is encoded and appended as a query string
+        to the URL. If body dict is provided, it is serialied as JSON and used
+        as the HTTP body (with Content-Type: "application/json"). The resulting
+        body is decoded from JSON.
+        """
+        headers = {'Accept': 'application/json'}
+        data = None
+        if body is not None:
+            data = json.dumps(body).encode('utf-8')
+            headers['Content-Type'] = 'application/json'
+
+        response = self.request_raw(method, path, query, headers, data)
+        self._ensure_content_type(response.headers, 'application/json')
+        raw_resp: Dict[str, Any] = json.loads(response.read())
+        return raw_resp
+
+    @staticmethod
+    def _ensure_content_type(headers: email.message.Message,
+                             expected: 'Literal["multipart/form-data", "application/json"]'):
+        """Parse Content-Type header from headers and ensure it's equal to expected.
+
+        Return a dict of any options in the header, e.g., {'boundary': ...}.
+        """
+        ctype = headers.get_content_type()
+        params = headers.get_params() or {}
+        options = {key: value for key, value in params if value}
+        if ctype != expected:
+            raise ProtocolError(f'expected Content-Type {expected!r}, got {ctype!r}')
+        return options
+
+    def request_raw(
+            self, method: str, path: str,
+            query: Optional[Dict[str, Any]] = None,
+            headers: Optional[Dict[str, Any]] = None,
+            data: Optional[Union[bytes, Generator[bytes, Any, Any]]] = None,
+    ) -> http.client.HTTPResponse:
+        """Make a request to the socket; return the raw HTTPResponse object."""
+        url = self.base_url + path
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query, doseq=True)}"
+
+        if headers is None:
+            headers = {}
+        request = urllib.request.Request(url, method=method, data=data, headers=headers)
+
+        try:
+            response = self.opener.open(request, timeout=self.timeout)
+        except urllib.error.HTTPError as e:
+            code = e.code
+            status = e.reason
+            try:
+                body: Dict[str, Any] = json.loads(e.read())
+                message: str = body['error']
+            except (OSError, ValueError, KeyError) as e2:
+                # Will only happen on read error or if the server sends invalid JSON.
+                body: Dict[str, Any] = {}
+                message = f'{type(e2).__name__} - {e2}'
+            raise APIError(body, code, status, message)
+        except urllib.error.URLError as e:
+            raise ConnectionError(e.reason)
+
+        return response
+
+
+class _NotProvidedFlag:
+    pass
+
+
+_not_provided = _NotProvidedFlag()
+
+
+class _UnixSocketHandler(urllib.request.AbstractHTTPHandler):
+    """Implementation of HTTPHandler that uses a named Unix socket."""
+
+    def __init__(self, socket_path: str):
+        super().__init__()
+        self.socket_path = socket_path
+
+    def http_open(self, req: urllib.request.Request):
+        """Override http_open to use a Unix socket connection (instead of TCP)."""
+        return self.do_open(_UnixSocketConnection, req,  # type:ignore
+                            socket_path=self.socket_path)
+
+
+class _UnixSocketConnection(http.client.HTTPConnection):
+    """Implementation of HTTPConnection that connects to a named Unix socket."""
+
+    def __init__(self, host: str, socket_path: str,
+                 timeout: Union[_NotProvidedFlag, float] = _not_provided):
+        if timeout is _not_provided:
+            super().__init__(host)
+        else:
+            assert isinstance(timeout, (int, float)), timeout  # type guard for pyright
+            super().__init__(host, timeout=timeout)
+        self.socket_path = socket_path
+
+    def connect(self):
+        """Override connect to use Unix socket (instead of TCP socket)."""
+        if not hasattr(socket, 'AF_UNIX'):
+            raise NotImplementedError(f'Unix sockets not supported on {sys.platform}')
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(self.socket_path)
+        if self.timeout is not _not_provided:
+            self.sock.settimeout(self.timeout)
+
+
+class Error(Exception):
+    """Base class of most errors raised by the client."""
+
+    def __repr__(self):
+        return f'<{type(self).__module__}.{type(self).__name__} {self.args}>'
+
+
+class ProtocolError(Error):
+    """Raised when there's a higher-level protocol error talking to the socket."""
+
+
+class ConnectionError(Error):
+    """Raised when the client can't connect to the socket."""
+
+
+class APIError(Error):
+    """Raised when an HTTP API error occurs talking to the Pebble server."""
+
+    body: Dict[str, Any]
+    """Body of the HTTP response, parsed as JSON."""
+
+    code: int
+    """HTTP status code."""
+
+    status: str
+    """HTTP status string (reason)."""
+
+    message: str
+    """Human-readable error message from the API."""
+
+    def __init__(self, body: Dict[str, Any], code: int, status: str, message: str):
+        """This shouldn't be instantiated directly."""
+        super().__init__(message)  # Makes str(e) return message
+        self.body = body
+        self.code = code
+        self.status = status
+        self.message = message
+
+    def __repr__(self):
+        return f'APIError({self.body!r}, {self.code!r}, {self.status!r}, {self.message!r})'

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -157,8 +157,12 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         mock_get_binding.return_value = mockBinding(['192.168.1.17'])
 
+        # This is an example of how the jujud invocation looks on machines/VMs.
+        pgrep = ('666 /var/lib/juju/tools/machine-0/jujud machine '
+                 '--data-dir /var/lib/juju --machine-id 0 --debug')
+
         # First call is to get the controller service name; last is for its PID.
-        mock_check_out.side_effect = ['jujud-machine-0.service', '12345']
+        mock_check_out.side_effect = [pgrep, pgrep]
 
         harness.set_leader()
 
@@ -204,8 +208,12 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         mock_get_binding.return_value = mockBinding(['192.168.1.17'])
 
+        # This is an example of how the jujud invocation looks on K8s.
+        pgrep = ('12345 /var/lib/juju/tools/jujud machine --data-dir '
+                 '/var/lib/juju --controller-id 0 --log-to-stderr')
+
         # First call is to get the controller service name; last is for its PID.
-        mock_check_out.side_effect = ['jujud-machine-0.service', '12345']
+        mock_check_out.side_effect = [pgrep, pgrep]
 
         relation_id = harness.add_relation('dbcluster', harness.charm.app)
         harness.add_relation_unit(relation_id, 'juju-controller/1')

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -9,7 +9,7 @@ import unittest
 import yaml
 
 from charm import JujuControllerCharm, AgentConfException
-from ops.model import BlockedStatus, ActiveStatus, ErrorStatus
+from ops.model import BlockedStatus, ActiveStatus
 from ops.testing import Harness
 from unittest.mock import mock_open, patch
 
@@ -139,7 +139,7 @@ class TestCharm(unittest.TestCase):
 
         harness.add_relation('metrics-endpoint', 'prometheus-k8s')
         harness.evaluate_status()
-        self.assertIsInstance(harness.charm.unit.status, ErrorStatus)
+        self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf_ipv4)
     def test_apiaddresses_ipv4(self, _):

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -157,9 +157,8 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         mock_get_binding.return_value = mockBinding(['192.168.1.17'])
 
-        # First calls are to get the controller service name; last is for its PID.
-        mock_check_out.side_effect = [
-            'jujud-machine-0.service', 'jujud-machine-0.service', b'pid=12345']
+        # First call is to get the controller service name; last is for its PID.
+        mock_check_out.side_effect = ['jujud-machine-0.service', '12345']
 
         harness.set_leader()
 
@@ -205,9 +204,8 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         mock_get_binding.return_value = mockBinding(['192.168.1.17'])
 
-        # First calls are to get the controller service name; last is for its PID.
-        mock_check_out.side_effect = [
-            'jujud-machine-0.service', 'jujud-machine-0.service', b'pid=12345']
+        # First call is to get the controller service name; last is for its PID.
+        mock_check_out.side_effect = ['jujud-machine-0.service', '12345']
 
         relation_id = harness.add_relation('dbcluster', harness.charm.app)
         harness.add_relation_unit(relation_id, 'juju-controller/1')

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -162,7 +162,7 @@ class TestCharm(unittest.TestCase):
 
         # Have another unit enter the relation.
         # Its bind address should end up in the application data bindings list.
-        relation_id = harness.add_relation('dbcluster', harness.charm.app.name)
+        relation_id = harness.add_relation('dbcluster', harness.charm.app)
         harness.add_relation_unit(relation_id, 'juju-controller/1')
         self.harness.update_relation_data(
             relation_id, 'juju-controller/1', {'db-bind-address': '192.168.1.100'})
@@ -183,7 +183,7 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         binding.return_value = mockBinding(["192.168.1.17", "192.168.1.18"])
 
-        relation_id = harness.add_relation('dbcluster', harness.charm.app.name)
+        relation_id = harness.add_relation('dbcluster', harness.charm.app)
         harness.add_relation_unit(relation_id, 'juju-controller/1')
 
         self.harness.update_relation_data(

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -19,7 +19,6 @@ class TestClass(unittest.TestCase):
             url='http://localhost/metrics-users',
             method='POST',
             body=r'{"username": "juju-metrics-r0", "password": "passwd"}',
-
             response=MockResponse(
                 headers=MockHeaders(content_type='application/json'),
                 body=r'{"message":"created user \"juju-metrics-r0\""}'
@@ -35,7 +34,6 @@ class TestClass(unittest.TestCase):
             url='http://localhost/metrics-users',
             method='POST',
             body=r'{"username": "juju-metrics-r0", "password": "passwd"}',
-
             error=urllib.error.HTTPError(
                 url='http://localhost/metrics-users',
                 code=409,
@@ -60,7 +58,6 @@ class TestClass(unittest.TestCase):
             url='http://localhost/metrics-users/juju-metrics-r0',
             method='DELETE',
             body=None,
-
             response=MockResponse(
                 headers=MockHeaders(content_type='application/json'),
                 body=r'{"message":"deleted user \"juju-metrics-r0\""}'
@@ -76,7 +73,6 @@ class TestClass(unittest.TestCase):
             url='http://localhost/metrics-users/juju-metrics-r0',
             method='DELETE',
             body=None,
-
             error=urllib.error.HTTPError(
                 url='http://localhost/metrics-users/juju-metrics-r0',
                 code=404,
@@ -101,12 +97,28 @@ class TestClass(unittest.TestCase):
             url='http://localhost/metrics-users',
             method='POST',
             body=r'{"username": "juju-metrics-r0", "password": "passwd"}',
-
             error=urllib.error.URLError('could not connect to socket')
         )
 
         with self.assertRaisesRegex(ConnectionError, 'could not connect to socket'):
             control_socket.add_metrics_user('juju-metrics-r0', 'passwd')
+
+    def test_get_controller_agent_id(self):
+        mock_opener = MockOpener(self)
+        config_reload_socket = ConfigChangeSocketClient('fake_socket_path', opener=mock_opener)
+
+        mock_opener.expect(
+            url='http://localhost/agent-id',
+            method='GET',
+            body=None,
+            response=MockResponse(
+                headers=MockHeaders(content_type='application/text'),
+                body=b'666'
+            )
+        )
+
+        id = config_reload_socket.get_controller_agent_id()
+        self.assertEqual(id, '666')
 
     def test_reload_config(self):
         mock_opener = MockOpener(self)
@@ -118,6 +130,7 @@ class TestClass(unittest.TestCase):
             body=None,
             response=None,
         )
+
         config_reload_socket.reload_config()
 
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -114,7 +114,7 @@ class TestClass(unittest.TestCase):
 
         mock_opener.expect(
             url='http://localhost/reload',
-            method='GET',
+            method='POST',
             body=None,
             response=None,
         )


### PR DESCRIPTION
This patch builds on the handler added to the controller configuration socket in https://github.com/juju/juju/pull/17002.

It supersedes #67, which in turn was based on #60.

This patch does two things:
- We no longer assume that the identity of the controller itself is congruent with the controller unit ID. We now get this information from the running controller jujud process.
- When the controller configuration file is changed, we send a reload request to the controller's configuration socket, causing a reload of the new configuration.

Note that this assumes that the charm _does not_ deploy the controller itself, which is how we ultimately want to manage HA control planes.

To verify:
- `charmcraft pack` this charm.
- Bootstrap a new LXD controller using `--controller-charm-path <path-to-packed-artefact>`.
- `juju enable-ha`.
- Once all units have joined the relation, ssh to the controller machine and check _/var/lib/juju/agents/controller-0/agent.conf_. It should be populated along the lines of:
```
db-bind-addresses:
  controller/0: 10.246.27.181
  controller/1: 10.246.27.53
  controller/2: 10.246.27.12
```
- `juju debug-log -m controller --replay|grep reload` will indicate signals across the different controllers.

https://warthogs.atlassian.net/browse/JUJU-5306