### PR TITLE
Update controller configuration path

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -262,7 +262,7 @@ class JujuControllerCharm(CharmBase):
         the local controller ID, then use it to construct a config path.
         """
         controller_id = self._config_change_socket.get_controller_agent_id()
-        return f'/var/lib/juju/agents/controller-{controller_id}/agent.conf'
+        return f'/var/lib/juju/agents/controller-{controller_id}/controller.conf'
 
     def _request_config_reload(self):
         """Send a reload request to the config reload socket"""

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -214,7 +214,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id, harness.charm.app.name, {'db-bind-addresses': json.dumps(bound)})
 
-        file_path = '/var/lib/juju/agents/controller-0/agent.conf'
+        file_path = '/var/lib/juju/agents/controller-0/controller.conf'
         self.assertEqual(mock_open.call_count, 2)
 
         # First call to read out the YAML


### PR DESCRIPTION
On K8s, the controller's agent configuration is in _/var/lib/juju/agents/controller-n/agent.conf_ instead of a path with _machine-n_ as on machines.

This means that we can't use _agent.conf_ for controller configuration written by the charm, because it overwrites the agent configuration.

Here we change the name to _controller.conf_ to avoid this situation.