### PR TITLE
Use the agent ID instead of unit ID in cluster config dict

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -171,12 +171,13 @@ class JujuControllerCharm(CharmBase):
             # The event only has *other* units so include this
             # unit's bind address if we have managed to set it.
             ip = self._stored.db_bind_address
-            all_bind_addresses = {self.unit.name: ip} if ip else dict()
+            all_bind_addresses = {self._controller_agent_id(): ip} if ip else dict()
 
             for unit in relation.units:
                 unit_data = relation.data[unit]
                 if self.DB_BIND_ADDR_KEY in unit_data:
-                    all_bind_addresses[unit.name] = unit_data[self.DB_BIND_ADDR_KEY]
+                    agent_id = unit_data[self.AGENT_ID_KEY]
+                    all_bind_addresses[agent_id] = unit_data[self.DB_BIND_ADDR_KEY]
 
             if self._stored.all_bind_addresses == all_bind_addresses:
                 return

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,6 +27,7 @@ class JujuControllerCharm(CharmBase):
     CONFIG_SOCKET_PATH = '/var/lib/juju/configchange.socket'
     DB_BIND_ADDR_KEY = 'db-bind-address'
     ALL_BIND_ADDRS_KEY = 'db-bind-addresses'
+    AGENT_ID_KEY = 'agent-id'
 
     _stored = StoredState()
 
@@ -211,7 +212,10 @@ class JujuControllerCharm(CharmBase):
             return
 
         logger.info('setting new DB bind address: %s', ip)
-        relation.data[self.unit].update({self.DB_BIND_ADDR_KEY: ip})
+        relation.data[self.unit].update({
+            self.DB_BIND_ADDR_KEY: ip,
+            self.AGENT_ID_KEY: self._controller_agent_id()
+        })
         self._stored.db_bind_address = ip
 
     def _update_config_file(self, bind_addresses):
@@ -261,11 +265,14 @@ class JujuControllerCharm(CharmBase):
         """Interrogate the running controller jujud service to determine
         the local controller ID, then use it to construct a config path.
         """
-        controller_id = self._config_change_socket.get_controller_agent_id()
+        controller_id = self._controller_agent_id()
         return f'/var/lib/juju/agents/controller-{controller_id}/controller.conf'
 
+    def _controller_agent_id(self):
+        return self._config_change_socket.get_controller_agent_id()
+
     def _request_config_reload(self):
-        """Send a reload request to the config reload socket"""
+        """Send a reload request to the config reload socket."""
         self._config_change_socket.reload_config()
 
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -158,16 +158,21 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         mock_get_binding.return_value = mockBinding(['192.168.1.17'])
 
+        # This unit's agent ID happends to correspond with the unit ID.
         mock_get_agent_id.return_value = '0'
 
         harness.set_leader()
 
         # Have another unit enter the relation.
         # Its bind address should end up in the application data bindings list.
+        # Note that the agent ID doesn not correspond with the unit's ID
         relation_id = harness.add_relation('dbcluster', harness.charm.app)
         harness.add_relation_unit(relation_id, 'juju-controller/1')
         self.harness.update_relation_data(
-            relation_id, 'juju-controller/1', {'db-bind-address': '192.168.1.100'})
+            relation_id, 'juju-controller/1', {
+                'db-bind-address': '192.168.1.100',
+                'agent-id': '9',
+            })
 
         mock_reload_config.assert_called_once()
 
@@ -176,7 +181,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(unit_data['agent-id'], '0')
 
         app_data = harness.get_relation_data(relation_id, 'juju-controller')
-        exp = {"juju-controller/0": "192.168.1.17", "juju-controller/1": "192.168.1.100"}
+        exp = {'0': '192.168.1.17', '9': '192.168.1.100'}
         self.assertEqual(json.loads(app_data['db-bind-addresses']), exp)
 
         harness.evaluate_status()

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -173,6 +173,7 @@ class TestCharm(unittest.TestCase):
 
         unit_data = harness.get_relation_data(relation_id, 'juju-controller/0')
         self.assertEqual(unit_data['db-bind-address'], '192.168.1.17')
+        self.assertEqual(unit_data['agent-id'], '0')
 
         app_data = harness.get_relation_data(relation_id, 'juju-controller')
         exp = {"juju-controller/0": "192.168.1.17", "juju-controller/1": "192.168.1.100"}


### PR DESCRIPTION
The `dbaccessor` working in the Juju agent needs recognise its own bind address in the configuration set for the cluster by the controller unit.

At this point in Juju's workflow, it does not have the knowledge to reconcile what its local controller _unit_ ID is.

To address this, the application data-bag cluster configuration, and therefore the contents written to disk are keyed on the agent ID rather than the unit ID.