### PR TITLE
Rename control socket to metric socket

### DIFF
--- a/src/metricsocket.py
+++ b/src/metricsocket.py
@@ -10,9 +10,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class ControlSocketClient(unixsocket.SocketClient):
+class MetricSocketClient(unixsocket.SocketClient):
     """
-    Client to Juju control socket.
+    Client to Juju metric socket.
     """
     def __init__(self, socket_path: str,
                  opener: Optional[urllib.request.OpenerDirector] = None):

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -85,8 +85,8 @@ class TestCharm(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
     @patch("charm.MetricsEndpointProvider", autospec=True)
     @patch("charm.generate_password", new=lambda: "passwd")
-    @patch("controlsocket.ControlSocketClient.add_metrics_user")
-    @patch("controlsocket.ControlSocketClient.remove_metrics_user")
+    @patch("metricsocket.MetricSocketClient.add_metrics_user")
+    @patch("metricsocket.MetricSocketClient.remove_metrics_user")
     def test_metrics_endpoint_relation(self, mock_remove_user, mock_add_user,
                                        mock_metrics_provider, _):
         harness = self.harness
@@ -133,7 +133,7 @@ class TestCharm(unittest.TestCase):
             harness.charm.api_port()
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf_apiaddresses_missing)
-    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    @patch("metricsocket.MetricSocketClient.add_metrics_user")
     def test_apiaddresses_missing_status(self, *_):
         harness = self.harness
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -5,7 +5,7 @@
 import io
 import unittest
 import urllib.error
-from controlsocket import ControlSocketClient
+from metricsocket import MetricSocketClient
 from configchangesocket import ConfigChangeSocketClient
 from unixsocket import APIError, ConnectionError
 
@@ -13,7 +13,7 @@ from unixsocket import APIError, ConnectionError
 class TestClass(unittest.TestCase):
     def test_add_metrics_user_success(self):
         mock_opener = MockOpener(self)
-        control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
+        metric_socket = MetricSocketClient('fake_socket_path', opener=mock_opener)
 
         mock_opener.expect(
             url='http://localhost/metrics-users',
@@ -24,11 +24,11 @@ class TestClass(unittest.TestCase):
                 body=r'{"message":"created user \"juju-metrics-r0\""}'
             )
         )
-        control_socket.add_metrics_user('juju-metrics-r0', 'passwd')
+        metric_socket.add_metrics_user('juju-metrics-r0', 'passwd')
 
     def test_add_metrics_user_fail(self):
         mock_opener = MockOpener(self)
-        control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
+        metric_socket = MetricSocketClient('fake_socket_path', opener=mock_opener)
 
         mock_opener.expect(
             url='http://localhost/metrics-users',
@@ -44,7 +44,7 @@ class TestClass(unittest.TestCase):
         )
 
         with self.assertRaises(APIError) as cm:
-            control_socket.add_metrics_user('juju-metrics-r0', 'passwd')
+            metric_socket.add_metrics_user('juju-metrics-r0', 'passwd')
         self.assertEqual(cm.exception.body, {'error': 'user "juju-metrics-r0" already exists'})
         self.assertEqual(cm.exception.code, 409)
         self.assertEqual(cm.exception.status, '')
@@ -52,7 +52,7 @@ class TestClass(unittest.TestCase):
 
     def test_remove_metrics_user_success(self):
         mock_opener = MockOpener(self)
-        control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
+        metric_socket = MetricSocketClient('fake_socket_path', opener=mock_opener)
 
         mock_opener.expect(
             url='http://localhost/metrics-users/juju-metrics-r0',
@@ -63,11 +63,11 @@ class TestClass(unittest.TestCase):
                 body=r'{"message":"deleted user \"juju-metrics-r0\""}'
             )
         )
-        control_socket.remove_metrics_user('juju-metrics-r0')
+        metric_socket.remove_metrics_user('juju-metrics-r0')
 
     def test_remove_metrics_user_fail(self):
         mock_opener = MockOpener(self)
-        control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
+        metric_socket = MetricSocketClient('fake_socket_path', opener=mock_opener)
 
         mock_opener.expect(
             url='http://localhost/metrics-users/juju-metrics-r0',
@@ -83,7 +83,7 @@ class TestClass(unittest.TestCase):
         )
 
         with self.assertRaises(APIError) as cm:
-            control_socket.remove_metrics_user('juju-metrics-r0')
+            metric_socket.remove_metrics_user('juju-metrics-r0')
         self.assertEqual(cm.exception.body, {'error': 'user "juju-metrics-r0" not found'})
         self.assertEqual(cm.exception.code, 404)
         self.assertEqual(cm.exception.status, '')
@@ -91,7 +91,7 @@ class TestClass(unittest.TestCase):
 
     def test_connection_error(self):
         mock_opener = MockOpener(self)
-        control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
+        metric_socket = MetricSocketClient('fake_socket_path', opener=mock_opener)
 
         mock_opener.expect(
             url='http://localhost/metrics-users',
@@ -101,7 +101,7 @@ class TestClass(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(ConnectionError, 'could not connect to socket'):
-            control_socket.add_metrics_user('juju-metrics-r0', 'passwd')
+            metric_socket.add_metrics_user('juju-metrics-r0', 'passwd')
 
     def test_get_controller_agent_id(self):
         mock_opener = MockOpener(self)


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
The control socket is used only for metrics and, despite the name, is not always available when the controller is. It relies on state. This means that it cannot be used for things like setting up dqlite cluster. Its name implies that it is general purpose and possibly could be used for something like that.

- Rename control socket to metric socket to more accurately reflect its purpose. 

## QA steps
**Note for reviewers**
If there is a better way to test that the metric socket is working here please let me know. I tried to follow the steps in https://github.com/juju/juju/pull/16301 but I got an error saying "cannot deploy local controller charm with k8s".

- `charmcraft pack` the the charm
- `make go-install` for juju in branch https://github.com/juju/juju/pull/17081
- `juju bootstrap lxd --controller-charm-path <path-to-packed-artefact>`
- `juju deploy juju-dashboard --channel beta`
- `juju integrate controller juju-dashboard`
<!-- Describe steps to verify that the change works. -->


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** JUJU-5564

