### PR TITLE
feat: add 24.04 as a supported Ubuntu base

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,6 +9,13 @@ bases:
           architectures: ["amd64"]
       run-on:
         - name: ubuntu
+          channel: "24.04"
+          architectures: 
+              - amd64
+              - aarch64
+              - arm64
+              - s390x
+        - name: ubuntu
           channel: "22.04"
           architectures: 
               - amd64


### PR DESCRIPTION
Adds the latest Ubuntu LTS as supported run-on base for the charm.

To test:
- Pull this patch and `charmcraft pack` it.
- `juju bootstrap lxd lxd --controller-charm-path <path-to-packed-charm> --bootstrap-base ubuntu@24.04 --force`.
- Juju comes up and the controller logs are free of errors.