### PR TITLE
chore: merge 3.4 into 3.5

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,6 +9,13 @@ bases:
           architectures: ["amd64"]
       run-on:
         - name: ubuntu
+          channel: "24.04"
+          architectures: 
+              - amd64
+              - aarch64
+              - arm64
+              - s390x
+        - name: ubuntu
           channel: "22.04"
           architectures: 
               - amd64


### PR DESCRIPTION
Merge from 3.4 to bring forward #75, which adds support for Ubuntu 24.04.