### PR TITLE
fix: correct architectures

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,20 +5,30 @@ parts:
 bases:
     - build-on:
         - name: ubuntu
-          channel: "22.04"
+          channel: "24.04"
           architectures: ["amd64"]
       run-on:
         - name: ubuntu
-          channel: "22.04"
-          architectures: 
+          channel: "24.04"
+          architectures:
               - amd64
-              - aarch64
               - arm64
               - s390x
+              - ppc64el
+              - riscv64
+        - name: ubuntu
+          channel: "22.04"
+          architectures:
+              - amd64
+              - arm64
+              - s390x
+              - ppc64el
+              - riscv64
         - name: ubuntu
           channel: "20.04"
-          architectures: 
+          architectures:
               - amd64
-              - aarch64
               - arm64
               - s390x
+              - ppc64el
+              - riscv64


### PR DESCRIPTION
The architectures in the charmcraft.yaml aren't correct. We've got duplicate arm64 architectures (arm64 and aarch64), so we should just pick one. Power PC was completely missing.

This charm currently only works by happenstance because what we build on is only amd64. If there were any architectual specific binaries we would stop working as we don't correctly build for those.