### PR TITLE
fix: add Cargo as a build dependency

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,6 +2,8 @@ type: charm
 parts:
   charm:
     charm-python-packages: [setuptools,markdown]
+    build-packages:
+      - cargo
 bases:
     - build-on:
         - name: ubuntu


### PR DESCRIPTION
This required in order to build the binary wheel(s) required by the included COS libs.