### PR TITLE
fix: add Cargo as a build dependency to charmcraft.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
     needs: unit-tests
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v4
     with:
+      charmcraft-snap-channel: 2.x/stable
       artifact-name: charm-packed
 
 
@@ -93,7 +94,7 @@ jobs:
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
         run: |
-          sudo snap install charmcraft --classic
+          sudo snap install charmcraft --channel 2.x/stable --classic
           charmcraft upload ${{ steps.download.outputs.download-path }}/*.charm \
             --name $CHARM_NAME \
             --release ${{ needs.channel.outputs.test }}
@@ -143,7 +144,7 @@ jobs:
 
     - name: Install Juju
       run: |
-        sudo snap install juju --channel 3.3/beta
+        sudo snap install juju --channel 3.5/stable
 
     - name: Bootstrap on LXD
       if: matrix.cloud == 'lxd'
@@ -179,7 +180,7 @@ jobs:
     steps:
     - name: Install Charmcraft
       run: |
-        sudo snap install charmcraft --classic
+        sudo snap install charmcraft --channel 2.x/stable --classic
 
     - name: Get uploaded revision
       id: revision

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,6 +2,8 @@ type: charm
 parts:
   charm:
     charm-python-packages: [setuptools,markdown]
+    build-packages:
+      - cargo
 bases:
     - build-on:
         - name: ubuntu


### PR DESCRIPTION
This adds Cargo as a dependency to charmcraft.yaml for building the charm.

It is required in order to build the binary wheel(s) required by the included COS libs.

In addition, we use the 2.x/stable version of charmcraft in workflows, so that we can include 24.04 in a list of run-on bases. Version 3 does not support this.