### PR TITLE
chore: merge 3.5 into 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
 
     - name: Install Juju
       run: |
-        sudo snap install juju --channel 3.5/stable
+        sudo snap install juju --channel 3.6/candidate
 
     - name: Bootstrap on LXD
       if: matrix.cloud == 'lxd'

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -14,20 +14,20 @@ bases:
           channel: "24.04"
           architectures: 
               - amd64
-              - aarch64
               - arm64
               - s390x
+              - ppc64el
         - name: ubuntu
           channel: "22.04"
           architectures: 
               - amd64
-              - aarch64
               - arm64
               - s390x
+              - ppc64el
         - name: ubuntu
           channel: "20.04"
           architectures: 
               - amd64
-              - aarch64
               - arm64
               - s390x
+              - ppc64el


### PR DESCRIPTION
Merge from 3.5 to bring forward build support for running on 24.04.

A correction to the list of architectures is slipstreamed in.