### PR TITLE
chore: use charmcraft 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
   build:
     name: Build charms
     needs: unit-tests
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v4
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23
     with:
-      charmcraft-snap-channel: 2.x/stable
+      charmcraft-snap-channel: 3.x/stable
       artifact-name: charm-packed
 
 
@@ -94,7 +94,7 @@ jobs:
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
         run: |
-          sudo snap install charmcraft --channel 2.x/stable --classic
+          sudo snap install charmcraft --channel 3.x/stable --classic
           charmcraft upload ${{ steps.download.outputs.download-path }}/*.charm \
             --name $CHARM_NAME \
             --release ${{ needs.channel.outputs.test }}
@@ -180,7 +180,7 @@ jobs:
     steps:
     - name: Install Charmcraft
       run: |
-        sudo snap install charmcraft --channel 2.x/stable --classic
+        sudo snap install charmcraft --channel 3.x/stable --classic
 
     - name: Get uploaded revision
       id: revision

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,30 +4,9 @@ parts:
     charm-python-packages: [setuptools,markdown]
     build-packages:
       - cargo
-bases:
-    - build-on:
-        - name: ubuntu
-          channel: "22.04"
-          architectures: ["amd64"]
-      run-on:
-        - name: ubuntu
-          channel: "24.04"
-          architectures: 
-              - amd64
-              - arm64
-              - s390x
-              - ppc64el
-        - name: ubuntu
-          channel: "22.04"
-          architectures: 
-              - amd64
-              - arm64
-              - s390x
-              - ppc64el
-        - name: ubuntu
-          channel: "20.04"
-          architectures: 
-              - amd64
-              - arm64
-              - s390x
-              - ppc64el
+base: ubuntu@24.04
+platforms:
+  amd64:
+  arm64:
+  s390x:
+  ppc64el:


### PR DESCRIPTION
We can only currently build for one base, but we can remote build on launchpad and thus get builds for all supported arches.

To publish the charm, we need to manually update the manifest to add support for 20.04 and 22.04.