### PR TITLE
chore: merge 3.6 to main with charmcraft 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,9 @@ jobs:
   build:
     name: Build charms
     needs: unit-tests
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v4
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23
     with:
-      charmcraft-snap-channel: 2.x/stable
-      artifact-name: charm-packed
+      charmcraft-snap-channel: 3.x/stable
 
 
   channel:
@@ -94,7 +93,7 @@ jobs:
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
         run: |
-          sudo snap install charmcraft --channel 2.x/stable --classic
+          sudo snap install charmcraft --channel 3.x/stable --classic
           charmcraft upload ${{ steps.download.outputs.download-path }}/*.charm \
             --name $CHARM_NAME \
             --release ${{ needs.channel.outputs.test }}
@@ -180,7 +179,7 @@ jobs:
     steps:
     - name: Install Charmcraft
       run: |
-        sudo snap install charmcraft --channel 2.x/stable --classic
+        sudo snap install charmcraft --channel 3.x/stable --classic
 
     - name: Get uploaded revision
       id: revision

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
 
     - name: Install Juju
       run: |
-        sudo snap install juju --channel 3.5/stable
+        sudo snap install juju --channel 3.6/candidate
 
     - name: Bootstrap on LXD
       if: matrix.cloud == 'lxd'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
     needs: unit-tests
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v4
     with:
+      charmcraft-snap-channel: 2.x/stable
       artifact-name: charm-packed
 
 
@@ -93,7 +94,7 @@ jobs:
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
         run: |
-          sudo snap install charmcraft --classic
+          sudo snap install charmcraft --channel 2.x/stable --classic
           charmcraft upload ${{ steps.download.outputs.download-path }}/*.charm \
             --name $CHARM_NAME \
             --release ${{ needs.channel.outputs.test }}
@@ -143,7 +144,7 @@ jobs:
 
     - name: Install Juju
       run: |
-        sudo snap install juju --channel 3.3/beta
+        sudo snap install juju --channel 3.5/stable
 
     - name: Bootstrap on LXD
       if: matrix.cloud == 'lxd'
@@ -179,7 +180,7 @@ jobs:
     steps:
     - name: Install Charmcraft
       run: |
-        sudo snap install charmcraft --classic
+        sudo snap install charmcraft --channel 2.x/stable --classic
 
     - name: Get uploaded revision
       id: revision

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,6 +9,13 @@ bases:
           architectures: ["amd64"]
       run-on:
         - name: ubuntu
+          channel: "24.04"
+          architectures: 
+              - amd64
+              - aarch64
+              - arm64
+              - s390x
+        - name: ubuntu
           channel: "22.04"
           architectures: 
               - amd64

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -14,20 +14,20 @@ bases:
           channel: "24.04"
           architectures: 
               - amd64
-              - aarch64
               - arm64
               - s390x
+              - ppc64el
         - name: ubuntu
           channel: "22.04"
           architectures: 
               - amd64
-              - aarch64
               - arm64
               - s390x
+              - ppc64el
         - name: ubuntu
           channel: "20.04"
           architectures: 
               - amd64
-              - aarch64
               - arm64
               - s390x
+              - ppc64el

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,30 +4,9 @@ parts:
     charm-python-packages: [setuptools,markdown]
     build-packages:
       - cargo
-bases:
-    - build-on:
-        - name: ubuntu
-          channel: "22.04"
-          architectures: ["amd64"]
-      run-on:
-        - name: ubuntu
-          channel: "24.04"
-          architectures: 
-              - amd64
-              - arm64
-              - s390x
-              - ppc64el
-        - name: ubuntu
-          channel: "22.04"
-          architectures: 
-              - amd64
-              - arm64
-              - s390x
-              - ppc64el
-        - name: ubuntu
-          channel: "20.04"
-          architectures: 
-              - amd64
-              - arm64
-              - s390x
-              - ppc64el
+base: ubuntu@24.04
+platforms:
+  amd64:
+  arm64:
+  s390x:
+  ppc64el:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,6 +2,8 @@ type: charm
 parts:
   charm:
     charm-python-packages: [setuptools,markdown]
+    build-packages:
+      - cargo
 bases:
     - build-on:
         - name: ubuntu

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1731797254,
+        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "juju controller charm shell";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
+  };
+
+  outputs = { self, nixpkgs, ... } @ inputs:
+    let
+      forAllSystems = inputs.nixpkgs.lib.genAttrs [
+        "aarch64-linux"
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
+    in
+    {
+      devShells = forAllSystems (system: {
+        default =
+          let
+            pkgs = nixpkgs.legacyPackages.${system};
+          in
+          pkgs.mkShell {
+            name = "juju-controller-charm";
+            # Enable experimental features without having to specify the argument
+            NIX_CONFIG = "experimental-features = nix-command flakes";
+            nativeBuildInputs = with pkgs; [
+              coreutils
+              findutils
+              zsh
+              python312
+            ];
+            shellHook = ''
+              exec zsh
+            '';
+          };
+      });
+    };
+}

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@
 # Licensed under the GPLv3, see LICENSE file for details.
 name: juju-controller
 assumes:
-- juju >= 3.3
+- juju >= 3.5
 description: |
   The Juju controller charm is used to expose various pieces
   of functionality of a Juju controller.

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,7 @@ from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.charm import RelationJoinedEvent, RelationDepartedEvent
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, ErrorStatus, Relation
+from ops.model import ActiveStatus, BlockedStatus, Relation
 from typing import List
 
 logger = logging.getLogger(__name__)
@@ -84,7 +84,8 @@ class JujuControllerCharm(CharmBase):
         try:
             api_port = self.api_port()
         except AgentConfException as e:
-            self.unit.status = ErrorStatus(f"can't read controller API port from agent.conf: {e}")
+            self.unit.status = BlockedStatus(
+                f"can't read controller API port from agent.conf: {e}")
             return
 
         metrics_endpoint = MetricsEndpointProvider(

--- a/src/charm.py
+++ b/src/charm.py
@@ -131,7 +131,7 @@ class JujuControllerCharm(CharmBase):
         except AgentConfException as e:
             logger.error('cannot read controller API port from agent configuration: %s', e)
             self.unit.status = BlockedStatus(
-                f"can't read controller API port from agent.conf: {e}")
+                f"cannot read controller API port from agent configuration: {e}")
             return
 
         metrics_endpoint = MetricsEndpointProvider(

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -140,7 +140,8 @@ class TestCharm(unittest.TestCase):
         harness.add_relation('metrics-endpoint', 'prometheus-k8s')
         harness.evaluate_status()
         self.assertEqual(harness.charm.unit.status, BlockedStatus(
-            "can't read controller API port from agent.conf: agent.conf key 'apiaddresses' missing"
+            "cannot read controller API port from agent configuration: "
+            "agent.conf key 'apiaddresses' missing"
         ))
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf_ipv4)

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -4,7 +4,7 @@
 import os
 import unittest
 from charm import JujuControllerCharm, AgentConfException
-from ops import ErrorStatus
+from ops import BlockedStatus
 from ops.testing import Harness
 from unittest.mock import mock_open, patch
 
@@ -140,7 +140,7 @@ class TestCharm(unittest.TestCase):
         harness.begin()
 
         harness.add_relation('metrics-endpoint', 'prometheus-k8s')
-        self.assertEqual(harness.charm.unit.status, ErrorStatus(
+        self.assertEqual(harness.charm.unit.status, BlockedStatus(
             "can't read controller API port from agent.conf: agent.conf key 'apiaddresses' missing"
         ))
 


### PR DESCRIPTION
Depends on #84

Revisions 117, 118, 119 and 120 are based on this. Following the same patching @wallyworld did for 3.6.