### PR TITLE
fix(charmcraft): revert cargo to charm build-packages

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,6 +2,8 @@ type: charm
 parts:
   charm:
     charm-python-packages: [setuptools,markdown]
+    build-packages:
+      - cargo
 
 platforms:
   ubuntu@22.04:amd64:


### PR DESCRIPTION
This PR reverts cargo to the charm part's build-packages in charmcraft.yaml so Rust-based dependencies can compile during charm build.

QA steps:
```
charmcraft remote-build --launchpad-accept-public-upload
# You should obtain all charms (for all supported platforms).
# You can reduce the platform list because for `riscv64` it takes hours...
```