### PR TITLE
use correct `ca` key in prometheus scrape_job

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -99,7 +99,7 @@ class JujuControllerCharm(ops.CharmBase):
                     "password": password,
                 },
                 "tls_config": {
-                    "ca_file": self.ca_cert(),
+                    "ca": self.ca_cert(),
                     "server_name": "juju-apiserver",
                 },
             }],


### PR DESCRIPTION
This PR uses the correct key for sharing inline CA certs.

# Issues:

- [OpentelemetryCollector for K8s](https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/132)
- [OpentelemetryCollector for VMs](https://github.com/canonical/opentelemetry-collector-operator/issues/111)


# Tandem PRs:

- [OpentelemetryCollector for K8s](https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/139)
- [OpenTelemetryCollecto for VMs](https://github.com/canonical/opentelemetry-collector-operator/pull/118)
- `cos-tool` update. ([this one](https://github.com/canonical/cos-tool/pull/28) or [this one](https://github.com/canonical/cos-tool/pull/27))


# How to test it:

Once all the tandem PRs are merged, follow the [testing instructions from this PR](https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/139)