### PR TITLE
chore: declare 26.04 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,7 @@ jobs:
 
       - name: Install charmcraft
         # We use latest because there's no 4.x track yet.
-        # We currently need edge to get 26.04 support.
-        run: sudo snap install charmcraft --classic --channel=latest/edge
+        run: sudo snap install charmcraft --classic --channel=latest/stable
 
       - name: Pack charm
         run: sg lxd -c "charmcraft pack"
@@ -136,7 +135,6 @@ jobs:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
         run: |
           # We use latest because there's no 4.x track yet.
-          # We currently need edge to get 26.04 support.
           sudo snap install charmcraft --channel latest/stable --classic
           for FILE in *.charm; do
             echo "Uploading: $FILE"
@@ -170,12 +168,12 @@ jobs:
       if: matrix.cloud == 'microk8s'
       uses: balchua/microk8s-actions@v0.4.2
       with:
-        channel: "1.35-strict/stable"
+        channel: "1.36-strict/stable"
         addons: '["dns", "hostpath-storage"]'
 
     - name: Install Juju
       run: |
-        sudo snap install juju --channel 3.6/candidate
+        sudo snap install juju --channel 3/stable
 
     - name: Bootstrap on LXD
       if: matrix.cloud == 'lxd'
@@ -188,7 +186,6 @@ jobs:
       run: |
         sg snap_microk8s <<EOF
           juju bootstrap microk8s c \
-            --config agent-stream=proposed \
             --controller-charm-channel=${{ needs.channel.outputs.test }}
         EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,9 @@ jobs:
           newgrp lxd
 
       - name: Install charmcraft
-        run: sudo snap install charmcraft --classic --channel=3.x/stable
+        # We use latest because there's no 4.x track yet.
+        # We currently need edge to get 26.04 support.
+        run: sudo snap install charmcraft --classic --channel=latest/edge
 
       - name: Pack charm
         run: sg lxd -c "charmcraft pack"
@@ -133,7 +135,9 @@ jobs:
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
         run: |
-          sudo snap install charmcraft --channel 3.x/stable --classic
+          # We use latest because there's no 4.x track yet.
+          # We currently need edge to get 26.04 support.
+          sudo snap install charmcraft --channel latest/stable --classic
           for FILE in *.charm; do
             echo "Uploading: $FILE"
             charmcraft upload --name "$CHARM_NAME" --release "${{ needs.channel.outputs.test }}" "$FILE" 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,20 +143,34 @@ jobs:
 
 
   integration:
-    name: "Integration tests"
+    name: Integration tests (${{ matrix.test_name }})
     runs-on: ubuntu-latest
     needs: [build, upload, channel]
     strategy:
       fail-fast: false
       matrix:
-        cloud: ["lxd", "microk8s"]
+        include:
+          - test_name: lxd-20.04
+            cloud: lxd
+            bootstrap_base: ubuntu@20.04
+          - test_name: lxd-22.04
+            cloud: lxd
+            bootstrap_base: ubuntu@22.04
+          - test_name: lxd-24.04
+            cloud: lxd
+            bootstrap_base: ubuntu@24.04
+          - test_name: lxd-26.04
+            cloud: lxd
+            bootstrap_base: ubuntu@26.04
+          - test_name: microk8s
+            cloud: microk8s
 
     steps:
     - name: Save charmcraft logs as artifact
       if: always() && steps.charmcraft.outcome != 'skipped'
       uses: actions/upload-artifact@v4
       with:
-        name: charmcraft-upload-logs
+        name: charmcraft-upload-logs-${{ matrix.test_name }}
         path: ~/.local/state/charmcraft/log/
       continue-on-error: true
 
@@ -179,6 +193,7 @@ jobs:
       if: matrix.cloud == 'lxd'
       run: |
         juju bootstrap lxd c \
+          --bootstrap-base=${{ matrix.bootstrap_base }} \
           --controller-charm-channel=${{ needs.channel.outputs.test }}
 
     - name: Bootstrap on MicroK8s
@@ -200,7 +215,7 @@ jobs:
           juju status
           sleep 10
 
-          elapsed=$(date -u +%s)-${start_time}
+          elapsed=$(( $(date -u +%s) - start_time ))
           if [[ ${elapsed} -ge 600 ]]; then
             echo "Timed out waiting for controller to become active"
             juju status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
       if: matrix.cloud == 'microk8s'
       uses: balchua/microk8s-actions@v0.4.2
       with:
-        channel: "1.25-strict/stable"
+        channel: "1.35-strict/stable"
         addons: '["dns", "hostpath-storage"]'
 
     - name: Install Juju
@@ -188,6 +188,7 @@ jobs:
       run: |
         sg snap_microk8s <<EOF
           juju bootstrap microk8s c \
+            --config agent-stream=proposed \
             --controller-charm-channel=${{ needs.channel.outputs.test }}
         EOF
 
@@ -215,7 +216,11 @@ jobs:
       run: |
         set -x
         set +e
-        juju status
+        juju status -m controller
         juju debug-log -m controller --replay
+        sg snap_microk8s <<EOF
+          microk8s.kubectl -n controller-c get all
+          microk8s.kubectl -n controller-c get -o yaml pod/controller-0
+        EOF
 
     # TODO: test integration with dashboard / ha-proxy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 You will need to have Python 3, Charmcraft and [uv](https://docs.astral.sh/uv/) installed.
 ```
-sudo snap install charmcraft --classic
+sudo snap install charmcraft --classic --channel latest/stable
 sudo snap install astral-uv --classic
 ```
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -20,3 +20,7 @@ platforms:
   ubuntu@24.04:arm64:
   ubuntu@24.04:s390x:
   ubuntu@24.04:ppc64el:
+  ubuntu@26.04:amd64:
+  ubuntu@26.04:arm64:
+  ubuntu@26.04:s390x:
+  ubuntu@26.04:ppc64el:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ dependencies = [
     "ops",
     "charmhelpers",
     "cosl",
-    "PyYAML"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "ops",
     "charmhelpers",
     "cosl",
+    "PyYAML"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Add 26.04 support in charmcraft.yaml

The post bootstrap tests have also been expanded on lxd to specifically test 20.04, 22.04, 24.04, 26.04.

```
juju bootstrap lxd --bootstrap-base ubuntu@26.04 --controller-charm-channel=latest/edge/racoon-support-76649a4e32dee0d5fc9b13555b2746ae30eac9f7

Model       Controller           Cloud/Region         Version  Timestamp
controller  localhost-localhost  localhost/localhost  3.6.23   10:19:14+10:00

App         Version  Status  Scale  Charm            Channel                                                              Rev  Exposed  Message
controller           active      1  juju-controller  latest/edge/racoon-support-b30eea4efa79abfe4d9f101ddc242dd9f1c97e41  183  yes      

Unit           Workload  Agent  Machine  Public address  Ports      Message
controller/0*  active    idle   0        10.68.47.74     17022/tcp  

Machine  State    Address      Inst id        Base          AZ          Message
0        started  10.68.47.74  juju-38d4e0-0  ubuntu@26.04  wallyworld  Running
```

```
juju bootstrap microk8s  --controller-charm-channel=latest/edge/racoon-support-76649a4e32dee0d5fc9b13555b2746ae30eac9f7
Creating Juju controller "microk8s-localhost" on microk8s/localhost
Bootstrap to Kubernetes cluster identified as microk8s/localhost
Creating k8s resources for controller "controller-microk8s-localhost"
Starting controller pod
Bootstrap agent now started
Contacting Juju controller at 10.152.183.121 to verify accessibility...

Bootstrap complete, controller "microk8s-localhost" is now available in namespace "controller-microk8s-localhost"

Now you can run
        juju add-model <model-name>
to create a new model to deploy k8s workloads.

Model       Controller          Cloud/Region        Version  SLA          Timestamp
controller  microk8s-localhost  microk8s/localhost  3.6.23   unsupported  11:13:44+10:00

App         Version  Status  Scale  Charm            Channel                                                              Rev  Address  Exposed  Message
controller           active      1  juju-controller  latest/edge/racoon-support-dde783b2b3b3148f835d6c4afa1ba26f756b2a65  182           yes      

Unit           Workload  Agent  Address     Ports      Message
controller/0*  active    idle   10.1.78.89  37017/TCP  
```