### PR TITLE
chore: revert "Merge pull request #101"

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -99,7 +99,7 @@ class JujuControllerCharm(ops.CharmBase):
                     "password": password,
                 },
                 "tls_config": {
-                    "ca": self.ca_cert(),
+                    "ca_file": self.ca_cert(),
                     "server_name": "juju-apiserver",
                 },
             }],

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -102,7 +102,7 @@ class TestCharm(unittest.TestCase):
                     "password": 'passwd',
                 },
                 "tls_config": {
-                    "ca": 'fake',
+                    "ca_file": 'fake',
                     "server_name": "juju-apiserver",
                 },
             }],


### PR DESCRIPTION
This reverts commit 95d29e58d49d7cfc8ee8c2ce0cc6fec381872986, reversing changes made to abb5f63c279ea3a53f032650c09c65a5fe0cb592.

The change to the tls_config key is a breaking change and breaks the ability to relate to the prometheus charm.

## QA

```
juju bootstrap microk8s test --controller-charm-channel=latest/edge/revert-pr-101-59d4220df484941dbc12771af96e4e342f83256c
juju offer controller.controller:metrics-endpoint
juju add-model test
juju deploy prometheus-k8s --channel 1/stable --trust
juju relate prometheus-k8s controller.controller

# 10.152.183.105 is the address of the prometheus unit
curl -sSm 2 "http://10.152.183.105:9090/api/v1/targets" | jq '.data.activeTargets[] | select(.labels.juju_application == "controller")'
{
  "discoveredLabels": {
    "__address__": "10.1.78.90:17070",
    "__metrics_path__": "/introspection/metrics",
    "__scheme__": "https",
    "__scrape_interval__": "1m",
    "__scrape_timeout__": "10s",
    "job": "juju_controller_fdfb9d27_controller_prometheus_scrape-0",
    "juju_application": "controller",
    "juju_charm": "juju-controller",
    "juju_model": "controller",
    "juju_model_uuid": "fdfb9d27-e3aa-4d26-8707-f497adf9b3ca",
    "juju_unit": "controller/0"
  },
  "labels": {
    "instance": "controller_fdfb9d27-e3aa-4d26-8707-f497adf9b3ca_controller_controller/0",
    "job": "juju_controller_fdfb9d27_controller_prometheus_scrape-0",
    "juju_application": "controller",
    "juju_charm": "juju-controller",
    "juju_model": "controller",
    "juju_model_uuid": "fdfb9d27-e3aa-4d26-8707-f497adf9b3ca",
    "juju_unit": "controller/0"
  },
  "scrapePool": "juju_controller_fdfb9d27_controller_prometheus_scrape-0",
  "scrapeUrl": "https://10.1.78.90:17070/introspection/metrics",
  "globalUrl": "https://10.1.78.90:17070/introspection/metrics",
  "lastError": "",
  "lastScrape": "2026-03-05T04:27:11.4423186Z",
  "lastScrapeDuration": 0.027761802,
  "health": "up",
  "scrapeInterval": "1m",
  "scrapeTimeout": "10s"
}
```