### PR TITLE
fix: restore local multi-arch pack support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,15 +72,15 @@ $ charmcraft upload *.charm --name juju-controller
 Revision [XX] of 'juju-controller' created
 ```
 
-Finally, release it to the relevant channels. Along with a `latest` track, we maintain a track for every minor version of Juju, e.g. `3.0`, `3.1`, etc.
+Finally, release it to the relevant channels. Along with a `latest` track, we maintain a track for every minor version of Juju, e.g. `3.6`, `4.0`, etc.
 ```console
-$ charmcraft release juju-controller --revision [XX] --channel latest/stable --channel 3.0/stable
-Revision [XX] of charm 'juju-controller' released to latest/stable, 3.0/stable
+$ charmcraft release juju-controller --revision [XX] --channel latest/stable --channel 3.6/stable
+Revision [XX] of charm 'juju-controller' released to latest/stable, 3.6/stable
 ```
 
 You can also do the upload and release in a single step if you'd like:
 ```console
-$ charmcraft upload *.charm --name juju-controller --release latest/stable --release 3.0/stable
+$ charmcraft upload *.charm --name juju-controller --release latest/stable --release 3.6/stable
 Revision [XX] of 'juju-controller' created
-Revision [XX] of charm 'juju-controller' released to latest/stable, 3.0/stable
+Revision [XX] of charm 'juju-controller' released to latest/stable, 3.6/stable
 ```

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,15 +8,39 @@ parts:
     build-snaps: [astral-uv]
 
 platforms:
-  ubuntu@20.04:amd64:
-  ubuntu@20.04:arm64:
-  ubuntu@20.04:s390x:
-  ubuntu@20.04:ppc64el:
-  ubuntu@22.04:amd64:
-  ubuntu@22.04:arm64:
-  ubuntu@22.04:s390x:
-  ubuntu@22.04:ppc64el:
-  ubuntu@24.04:amd64:
-  ubuntu@24.04:arm64:
-  ubuntu@24.04:s390x:
-  ubuntu@24.04:ppc64el:
+  ubuntu-20.04-amd64:
+    build-on: [ubuntu@20.04:amd64]
+    build-for: [ubuntu@20.04:amd64]
+  ubuntu-20.04-arm64:
+    build-on: [ubuntu@20.04:amd64]
+    build-for: [ubuntu@20.04:arm64]
+  ubuntu-20.04-s390x:
+    build-on: [ubuntu@20.04:amd64]
+    build-for: [ubuntu@20.04:s390x]
+  ubuntu-20.04-ppc64el:
+    build-on: [ubuntu@20.04:amd64]
+    build-for: [ubuntu@20.04:ppc64el]
+  ubuntu-22.04-amd64:
+    build-on: [ubuntu@22.04:amd64]
+    build-for: [ubuntu@22.04:amd64]
+  ubuntu-22.04-arm64:
+    build-on: [ubuntu@22.04:amd64]
+    build-for: [ubuntu@22.04:arm64]
+  ubuntu-22.04-s390x:
+    build-on: [ubuntu@22.04:amd64]
+    build-for: [ubuntu@22.04:s390x]
+  ubuntu-22.04-ppc64el:
+    build-on: [ubuntu@22.04:amd64]
+    build-for: [ubuntu@22.04:ppc64el]
+  ubuntu-24.04-amd64:
+    build-on: [ubuntu@24.04:amd64]
+    build-for: [ubuntu@24.04:amd64]
+  ubuntu-24.04-arm64:
+    build-on: [ubuntu@24.04:amd64]
+    build-for: [ubuntu@24.04:arm64]
+  ubuntu-24.04-s390x:
+    build-on: [ubuntu@24.04:amd64]
+    build-for: [ubuntu@24.04:s390x]
+  ubuntu-24.04-ppc64el:
+    build-on: [ubuntu@24.04:amd64]
+    build-for: [ubuntu@24.04:ppc64el]


### PR DESCRIPTION
#103 took away (accidentally?) the ability to locally pack the charm for multiple arches.
https://github.com/juju/juju-controller/pull/103/changes/54bd27d6175b0d4976a8caba56e328c6417ef57c

This PR restores that ability. It assumes we want to build on amd64 as did the original.
It seems remote-build (to build on launchpad) is broken?
```
$ charmcraft remote-build --launchpad-accept-public-upload
remote-build is experimental and is subject to change. Use with caution.
charmcraft internal error: AttributeError("'ProjectService' object has no attribute 'name'")
```
So for now we'll need to build locally and upload and release by hand, or maybe I'm holding remote-build wrongly.

# QA

```
$ charmcraft pack
Packed juju-controller_ubuntu-20.04-amd64.charm
Packed juju-controller_ubuntu-20.04-arm64.charm
Packed juju-controller_ubuntu-20.04-s390x.charm
Packed juju-controller_ubuntu-20.04-ppc64el.charm
Packed juju-controller_ubuntu-22.04-amd64.charm
Packed juju-controller_ubuntu-22.04-arm64.charm
Packed juju-controller_ubuntu-22.04-s390x.charm
Packed juju-controller_ubuntu-22.04-ppc64el.charm
Packed juju-controller_ubuntu-24.04-amd64.charm
Packed juju-controller_ubuntu-24.04-arm64.charm
Packed juju-controller_ubuntu-24.04-s390x.charm
Packed juju-controller_ubuntu-24.04-ppc64el.charm
```

Also note that the running the github action to build and test the charm now correctly puts charms in each arch. You will note that builds of other PRs before this fix only made it to amd64. Maybe there's some secret sauce I'm not aware of but not sure of how we planned to publish across all arches?
```
         ubuntu 24.04 (amd64)    stable                                                                  -          -
                                 candidate                                                               -          -
                                 beta                                                                    -          -
                                 edge                                                                    -          -
                                 edge/fix-platform-definitions-708527189adb9d2231e587fa29179d8708ba8ac4  222        222         2026-04-04T00:00:00Z
                                 edge/racoon-support-442c3c58eb47339f1889263c01c162cb2083d75a            190        190         2026-04-01T00:00:00Z
                                 edge/racoon-support-737f1f64d4d99170a49ae041adabbd1eb080e14a            186        186         2026-04-01T00:00:00Z
                                 edge/racoon-support-dde783b2b3b3148f835d6c4afa1ba26f756b2a65            182        182         2026-04-01T00:00:00Z
                                 edge/racoon-support-e53f0bf31c0abf64b4d3c324037450a89fe2dae1            194        194         2026-04-01T00:00:00Z
                                 edge/revert-pr-101-59d4220df484941dbc12771af96e4e342f83256c             210        210         2026-04-04T00:00:00Z
         ubuntu 24.04 (arm64)    stable                                                                  -          -
                                 candidate                                                               -          -
                                 beta                                                                    -          -
                                 edge                                                                    -          -
                                 edge/fix-platform-definitions-708527189adb9d2231e587fa29179d8708ba8ac4  223        223         2026-04-04T00:00:00Z
         ubuntu 24.04 (ppc64el)  stable                                                                  -          -
                                 candidate                                                               -          -
                                 beta                                                                    -          -
                                 edge                                                                    -          -
                                 edge/fix-platform-definitions-708527189adb9d2231e587fa29179d8708ba8ac4  224        224         2026-04-04T00:00:00Z
         ubuntu 24.04 (s390x)    stable                                                                  -          -
                                 candidate                                                               -          -
                                 beta                                                                    -          -
                                 edge                                                                    -          -
                                 edge/fix-platform-definitions-708527189adb9d2231e587fa29179d8708ba8ac4  225        225         2026-04-04T00:00:00Z
```