### PR TITLE
feat: tempo integration

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,6 +21,11 @@ requires:
   tracing:
     interface: tracing
     limit: 1
+    optional: true
+  receive-ca-cert:
+    interface: certificate_transfer
+    limit: 1
+    optional: true
 
 peers:
   dbcluster:
@@ -49,3 +54,5 @@ charm-libs:
     version: "0"
   - lib: tempo_coordinator_k8s.tracing
     version: "0"
+  - lib: certificate_transfer_interface.certificate_transfer
+    version: "1"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,6 +17,11 @@ provides:
   metrics-endpoint:
     interface: prometheus_scrape
 
+requires:
+  tracing:
+    interface: tracing
+    limit: 1
+
 peers:
   dbcluster:
     interface: dbcluster
@@ -41,4 +46,6 @@ platforms:
 
 charm-libs:
   - lib: prometheus_k8s.prometheus_scrape
+    version: "0"
+  - lib: tempo_coordinator_k8s.tracing
     version: "0"

--- a/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
@@ -1,0 +1,702 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the certificate_transfer relation.
+
+This library contains the Requires and Provides classes for handling the
+certificate-transfer interface. It supports both v0 and v1 of the interface.
+
+For requirers, they will set version 1 in their application databag as a hint to
+the provider. They will read the databag from the provider first as v1, and fallback
+to v0 if the format does not match.
+
+For providers, they will check the version in the requirer's application databag,
+and send v1 if that version is set to 1, otherwise it will default to 0 for backwards
+compatibility.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.certificate_transfer_interface.v1.certificate_transfer
+```
+
+### Provider charm
+The provider charm is the charm providing public certificates to another charm that requires them.
+
+Example:
+```python
+from ops.charm import CharmBase, RelationJoinedEvent
+from ops.main import main
+
+from lib.charms.certificate_transfer_interface.v1.certificate_transfer import (
+    CertificateTransferProvides,
+)
+
+class DummyCertificateTransferProviderCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.certificate_transfer = CertificateTransferProvides(self, "certificates")
+        self.framework.observe(
+            self.on.certificates_relation_joined, self._on_certificates_relation_joined
+        )
+
+    def _on_certificates_relation_joined(self, event: RelationJoinedEvent):
+        certificate = "my certificate"
+        self.certificate_transfer.add_certificates(certificate)
+
+
+if __name__ == "__main__":
+    main(DummyCertificateTransferProviderCharm)
+```
+
+### Requirer charm
+The requirer charm is the charm requiring certificates from another charm that provides them.
+
+Example:
+```python
+import logging
+
+from ops.charm import CharmBase
+from ops.main import main
+
+from lib.charms.certificate_transfer_interface.v1.certificate_transfer import (
+    CertificatesAvailableEvent,
+    CertificatesRemovedEvent,
+    CertificateTransferRequires,
+)
+
+
+class DummyCertificateTransferRequirerCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.certificate_transfer = CertificateTransferRequires(self, "certificates")
+        self.framework.observe(
+            self.certificate_transfer.on.certificate_set_updated, self._on_certificates_available
+        )
+        self.framework.observe(
+            self.certificate_transfer.on.certificates_removed, self._on_certificates_removed
+        )
+
+    def _on_certificates_available(self, event: CertificatesAvailableEvent):
+        logging.info(event.certificates)
+        logging.info(event.relation_id)
+
+    def _on_certificates_removed(self, event: CertificatesRemovedEvent):
+        logging.info(event.relation_id)
+
+
+if __name__ == "__main__":
+    main(DummyCertificateTransferRequirerCharm)
+```
+
+You can integrate both charms by running:
+
+```bash
+juju integrate <certificate_transfer provider charm> <certificate_transfer requirer charm>
+```
+
+"""
+
+import json
+import logging
+from typing import Dict, List, MutableMapping, Optional, Set
+
+import pydantic
+from ops import (
+    CharmEvents,
+    EventBase,
+    EventSource,
+    Handle,
+    Relation,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+)
+from ops.charm import CharmBase
+from ops.framework import Object
+
+# The unique Charmhub library identifier, never change it
+LIBID = "3785165b24a743f2b0c60de52db25c8b"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 15
+
+logger = logging.getLogger(__name__)
+
+PYDEPS = ["pydantic"]
+
+IS_PYDANTIC_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
+
+
+class TLSCertificatesError(Exception):
+    """Base class for custom errors raised by this library."""
+
+
+class DataValidationError(TLSCertificatesError):
+    """Raised when data validation fails."""
+
+
+class DatabagModel(pydantic.BaseModel):
+    """Base databag model.
+
+    Supports both pydantic v1 and v2.
+    """
+
+    if IS_PYDANTIC_V1:
+
+        class Config:
+            """Pydantic config."""
+
+            # ignore any extra fields in the databag
+            extra = "ignore"
+            """Ignore any extra fields in the databag."""
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+    model_config = pydantic.ConfigDict(
+        # tolerate additional keys in databag
+        extra="ignore",
+        # Allow instantiating this class by field name (instead of forcing alias).
+        populate_by_name=True,
+        # Custom config key: whether to nest the whole datastructure (as json)
+        # under a field or spread it out at the toplevel.
+        _NEST_UNDER=None,
+    )  # type: ignore
+    """Pydantic config."""
+
+    @classmethod
+    def load(cls, databag: MutableMapping):
+        """Load this model from a Juju databag."""
+        if IS_PYDANTIC_V1:
+            return cls._load_v1(databag)
+        nest_under = cls.model_config.get("_NEST_UNDER")
+        if nest_under:
+            return cls.model_validate(json.loads(databag[nest_under]))
+
+        try:
+            data = {
+                k: json.loads(v)
+                for k, v in databag.items()
+                # Don't attempt to parse model-external values
+                if k in {(f.alias or n) for n, f in cls.model_fields.items()}
+            }
+        except json.JSONDecodeError as e:
+            msg = f"invalid databag contents: expecting json. {databag}"
+            logger.error(msg)
+            raise DataValidationError(msg) from e
+
+        try:
+            return cls.model_validate_json(json.dumps(data))
+        except pydantic.ValidationError as e:
+            msg = f"failed to validate databag: {databag}"
+            logger.debug(msg, exc_info=True)
+            raise DataValidationError(msg) from e
+
+    @classmethod
+    def _load_v1(cls, databag: MutableMapping):
+        """Load implementation for pydantic v1."""
+        if cls._NEST_UNDER:
+            return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+        try:
+            data = {
+                k: json.loads(v)
+                for k, v in databag.items()
+                # Don't attempt to parse model-external values
+                if k in {f.alias for f in cls.__fields__.values()}
+            }
+        except json.JSONDecodeError as e:
+            msg = f"invalid databag contents: expecting json. {databag}"
+            logger.error(msg)
+            raise DataValidationError(msg) from e
+
+        try:
+            return cls.parse_raw(json.dumps(data))  # type: ignore
+        except pydantic.ValidationError as e:
+            msg = f"failed to validate databag: {databag}"
+            logger.debug(msg, exc_info=True)
+            raise DataValidationError(msg) from e
+
+    def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+        """Write the contents of this model to Juju databag.
+
+        Args:
+            databag: The databag to write to.
+            clear: Whether to clear the databag before writing.
+
+        Returns:
+            MutableMapping: The databag.
+        """
+        if IS_PYDANTIC_V1:
+            return self._dump_v1(databag, clear)
+        if clear and databag:
+            databag.clear()
+
+        if databag is None:
+            databag = {}
+        nest_under = self.model_config.get("_NEST_UNDER")
+        if nest_under:
+            databag[nest_under] = self.model_dump_json(
+                by_alias=True,
+                # skip keys whose values are default
+                exclude_defaults=True,
+            )
+            return databag
+
+        dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=False)
+        databag.update({k: json.dumps(v) for k, v in dct.items()})
+        return databag
+
+    def _dump_v1(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+        """Dump implementation for pydantic v1."""
+        if clear and databag:
+            databag.clear()
+
+        if databag is None:
+            databag = {}
+
+        if self._NEST_UNDER:
+            databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=False)
+            return databag
+
+        dct = json.loads(self.json(by_alias=True, exclude_defaults=False))
+        databag.update({k: json.dumps(v) for k, v in dct.items()})
+
+        return databag
+
+
+class ProviderApplicationData(DatabagModel):
+    """Provider App databag model."""
+
+    if int(pydantic.version.VERSION.split(".")[0]) < 2:
+        certificates: Set[str] = pydantic.Field(
+            description="The set of certificates that will be transferred to a requirer",
+            default_factory=set,
+        )
+    else:
+        certificates: Set[str] = pydantic.Field(
+            description="The set of certificates that will be transferred to a requirer",
+            default=set(),
+        )
+    version: int = pydantic.Field(
+        description="Version of the interface used in this databag",
+        default=1,
+    )
+
+
+class ProviderUnitDataV0(DatabagModel):
+    """Provider Unit databag v0 model."""
+
+    ca: str
+    certificate: str
+    chain: Optional[List[str]] = None
+    version: int = pydantic.Field(
+        description="Version of the interface used in this databag",
+        default=0,
+    )
+
+
+class RequirerApplicationData(DatabagModel):
+    """Requirer App databag model."""
+
+    version: int = pydantic.Field(
+        description="Version of the interface supported by this requirer",
+        default=1,
+    )
+
+
+class CertificateTransferProvides(Object):
+    """Certificate Transfer provider class to be instantiated by charms sending certificates."""
+
+    def __init__(self, charm: CharmBase, relationship_name: str):
+        super().__init__(charm, relationship_name + "_v1")
+        self.charm = charm
+        self.relationship_name = relationship_name
+
+    def add_certificates(self, certificates: Set[str], relation_id: Optional[int] = None) -> None:
+        """Add certificates from a set to relation data.
+
+        Adds certificate to all relations if relation_id is not provided.
+
+        Args:
+            certificates (Set[str]): A set of certificate strings in PEM format
+            relation_id (int): Juju relation ID
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            logger.warning("Only the leader unit can add certificates to this relation")
+            return
+        relations = self._get_active_relations(relation_id)
+        if not relations:
+            if relation_id is not None:
+                logger.debug(
+                    "At least 1 matching relation ID not found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            else:
+                logger.debug(
+                    "No active relations found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            return
+
+        for relation in relations:
+            existing_data = self._get_relation_data(relation)
+            existing_data.update(certificates)
+            self._set_relation_data(relation, existing_data)
+
+    def remove_all_certificates(self, relation_id: Optional[int] = None) -> None:
+        """Remove all certificates from relation data.
+
+        Removes all certificates from all relations if relation_id not given
+
+        Args:
+            relation_id (int): Relation ID
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            logger.warning("Only the leader unit can add certificates to this relation")
+            return
+        relations = self._get_active_relations(relation_id)
+        if not relations:
+            if relation_id is not None:
+                logger.debug(
+                    "At least 1 matching relation ID not found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            else:
+                logger.debug(
+                    "No active relations found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            return
+
+        for relation in relations:
+            self._set_relation_data(relation, set())
+
+    def remove_certificate(
+        self,
+        certificate: str,
+        relation_id: Optional[int] = None,
+    ) -> None:
+        """Remove a given certificate from relation data.
+
+        Removes certificate from all relations if relation_id not given
+
+        Args:
+            certificate (str): Certificate in PEM format that's in the list
+            relation_id (int): Relation ID
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            logger.warning("Only the leader unit can add certificates to this relation")
+            return
+        relations = self._get_active_relations(relation_id)
+        if not relations:
+            if relation_id is not None:
+                logger.debug(
+                    "At least 1 matching relation ID not found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            else:
+                logger.debug(
+                    "No active relations found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            return
+
+        for relation in relations:
+            existing_data = self._get_relation_data(relation)
+            existing_data.discard(certificate)
+            self._set_relation_data(relation, existing_data)
+
+    def _get_active_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
+        """Get the relation if relation_id is given and the relation is active, all active relations otherwise."""
+        if relation_id is not None:
+            relation = self.model.get_relation(
+                relation_name=self.relationship_name, relation_id=relation_id
+            )
+            if relation and relation.active:
+                return [relation]
+            return []
+
+        return [
+            relation
+            for relation in self.model.relations[self.relationship_name]
+            if relation.active
+        ]
+
+    def _set_relation_data(self, relation: Relation, data: Set[str]) -> None:
+        """Set the given relation data."""
+        if relation.data.get(relation.app, {}).get("version", "0") == "1":
+            databag = relation.data[self.model.app]
+            ProviderApplicationData(certificates=data).dump(databag, True)
+        else:
+            if "version" in relation.data.get(relation.app, {}):
+                logger.warning(
+                    (
+                        "Requirer in relation %d is using version %s of the interface,",
+                        "defaulting to version 0.",
+                        "This is deprecated, please consider upgrading the requirer",
+                        "to version 1 of the library.",
+                    ),
+                    relation.id,
+                    relation.data[relation.app]["version"],
+                )
+            else:
+                logger.warning(
+                    (
+                        "Requirer in relation %d did not provide version field,",
+                        "defaulting to version 0.",
+                        "This is deprecated, please consider upgrading the requirer",
+                        "to version 1 of the library.",
+                    ),
+                    relation.id,
+                )
+
+            databag = relation.data[self.model.unit]
+            if data:
+                certificates = list(data)
+                ProviderUnitDataV0(
+                    ca=certificates[0], certificate=certificates[0], chain=certificates
+                ).dump(databag, True)
+
+    def _get_relation_data(self, relation: Relation) -> Set[str]:
+        """Get the given relation data."""
+        try:
+            if relation.data.get(relation.app, {}).get("version", "0") == "1":
+                databag = relation.data[self.model.app]
+                return ProviderApplicationData().load(databag).certificates
+            else:
+                databag = relation.data[self.model.unit]
+                certs = ProviderUnitDataV0.load(databag).chain
+                if certs is None:
+                    return set()
+                return set(certs)
+        except DataValidationError as e:
+            logger.error(
+                (
+                    "Error parsing relation databag: %s. ",
+                    "Make sure not to interact with the databags "
+                    "except using the public methods in the provider library "
+                    "and use version V1.",
+                ),
+                e.args,
+            )
+            return set()
+
+
+class CertificatesAvailableEvent(EventBase):
+    """Charm Event triggered when the set of provided certificates is updated."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificates: Set[str],
+        relation_id: int,
+    ):
+        super().__init__(handle)
+        self.certificates = certificates
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {
+            "certificates": self.certificates,
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificates = snapshot["certificates"]
+        self.relation_id = snapshot["relation_id"]
+
+
+class CertificatesRemovedEvent(EventBase):
+    """Charm Event triggered when the set of provided certificates is removed."""
+
+    def __init__(self, handle: Handle, relation_id: int):
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {"relation_id": self.relation_id}
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.relation_id = snapshot["relation_id"]
+
+
+class CertificateTransferRequirerCharmEvents(CharmEvents):
+    """List of events that the Certificate Transfer requirer charm can leverage."""
+
+    certificate_set_updated = EventSource(CertificatesAvailableEvent)
+    certificates_removed = EventSource(CertificatesRemovedEvent)
+
+
+class CertificateTransferRequires(Object):
+    """Certificate transfer requirer class to be instantiated by charms expecting certificates."""
+
+    on = CertificateTransferRequirerCharmEvents()  # type: ignore
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relationship_name: str,
+    ):
+        """Observe events related to the relation.
+
+        Args:
+            charm: Charm object
+            relationship_name: Juju relation name
+        """
+        super().__init__(charm, relationship_name + "_v1")
+        self.relationship_name = relationship_name
+        self.charm = charm
+        self.framework.observe(
+            charm.on[relationship_name].relation_changed, self._on_relation_changed
+        )
+        self.framework.observe(
+            charm.on[relationship_name].relation_broken, self._on_relation_broken
+        )
+        self.framework.observe(
+            charm.on[relationship_name].relation_created, self._on_relation_created
+        )
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Emit certificate set updated event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        remote_unit_relation_data = self.get_all_certificates(event.relation.id)
+        self.on.certificate_set_updated.emit(
+            certificates=remote_unit_relation_data,
+            relation_id=event.relation.id,
+        )
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handle relation broken event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        self.on.certificates_removed.emit(relation_id=event.relation.id)
+
+    def _on_relation_created(self, event: RelationCreatedEvent) -> None:
+        """Handle relation created event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        if not self.model.unit.is_leader():
+            logger.debug("Only leader unit sets the version number in the app databag")
+            return
+        databag = event.relation.data[self.model.app]
+        RequirerApplicationData().dump(databag, False)
+
+    def get_all_certificates(self, relation_id: Optional[int] = None) -> Set[str]:
+        """Get transferred certificates.
+
+        If no relation id is given, certificates from all relations will be
+        provided in a concatenated list.
+
+        Args:
+            relation_id: The id of the relation to get the certificates from.
+        """
+        relations = self._get_active_relations(relation_id)
+        result = set()
+        for relation in relations:
+            data = self._get_relation_data(relation)
+            result = result.union(data)
+        return result
+
+    def get_all_certificates_by_relation(
+        self, relation_id: Optional[int] = None
+    ) -> Dict[int, List[str]]:
+        """Get a deterministic list of certificates grouped by relation.
+
+        - Grouped by relation_id.
+        - The list order is sorted lexicographically by PEM content.
+
+        Args:
+            relation_id: If provided, only certificates for this relation are returned.
+
+        Returns:
+            Dict where keys are relation IDs and values are ordered lists of PEMs.
+        """
+        relations = self._get_active_relations(relation_id)
+        result: Dict[int, List[str]] = {}
+        for relation in relations:
+            certificates = sorted(self._get_relation_data(relation))
+            result[relation.id] = certificates
+        return result
+
+    def is_ready(self, relation: Relation) -> bool:
+        """Check if the relation is ready by checking that it has valid relation data."""
+        databag = relation.data[relation.app]
+        try:
+            ProviderApplicationData().load(databag)
+            return True
+        except DataValidationError:
+            return False
+
+    def _get_relation_data(self, relation: Relation) -> Set[str]:
+        """Get the given relation data."""
+        try:
+            databag = relation.data[relation.app]
+            certificates = ProviderApplicationData().load(databag).certificates
+            if not certificates and relation.units:
+                databag = relation.data.get(relation.units.pop(), {})
+                certs = ProviderUnitDataV0.load(databag).chain
+                if certs is None:
+                    return set()
+                return set(certs)
+            return certificates
+        except DataValidationError as e:
+            logger.error(
+                (
+                    "Error parsing relation databag: %s. ",
+                    "Make sure not to interact with the databags "
+                    "except using the public methods in the provider library "
+                    "and use version V1.",
+                ),
+                e.args,
+            )
+            return set()
+
+    def _get_active_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
+        """Get the active relation if relation_id is given, all active relations otherwise."""
+        if relation_id is not None:
+            if relation := self.model.get_relation(
+                relation_name=self.relationship_name, relation_id=relation_id
+            ):
+                return [relation]
+        return [
+            relation
+            for relation in self.model.relations[self.relationship_name]
+            if relation.active
+        ]

--- a/lib/charms/tempo_coordinator_k8s/v0/tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tracing.py
@@ -1,0 +1,1010 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""## Overview.
+
+This document explains how to integrate with the Tempo charm for the purpose of pushing traces to a
+tracing endpoint provided by Tempo. It also explains how alternative implementations of the Tempo charm
+may maintain the same interface and be backward compatible with all currently integrated charms.
+
+## Requirer Library Usage
+
+Charms seeking to push traces to Tempo, must do so using the `TracingEndpointRequirer`
+object from this charm library. For the simplest use cases, using the `TracingEndpointRequirer`
+object only requires instantiating it, typically in the constructor of your charm. The
+`TracingEndpointRequirer` constructor requires the name of the relation over which a tracing endpoint
+ is exposed by the Tempo charm, and a list of protocols it intends to send traces with.
+ This relation must use the `tracing` interface.
+ The `TracingEndpointRequirer` object may be instantiated as follows
+
+    from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        # ...
+        self.tracing = TracingEndpointRequirer(self,
+            protocols=['otlp_grpc', 'otlp_http', 'jaeger_http_thrift']
+        )
+        # ...
+
+Note that the first argument (`self`) to `TracingEndpointRequirer` is always a reference to the
+parent charm.
+
+Alternatively to providing the list of requested protocols at init time, the charm can do it at
+any point in time by calling the
+`TracingEndpointRequirer.request_protocols(*protocol:str, relation:Optional[Relation])` method.
+Using this method also allows you to use per-relation protocols.
+
+Units of requirer charms obtain the tempo endpoint to which they will push their traces by calling
+`TracingEndpointRequirer.get_endpoint(protocol: str)`, where `protocol` is, for example:
+- `otlp_grpc`
+- `otlp_http`
+- `zipkin`
+- `tempo`
+
+If the `protocol` is not in the list of protocols that the charm requested at endpoint set-up time,
+the library will raise an error.
+
+We recommend that you scale up your tracing provider and relate it to an ingress so that your tracing requests
+go through the ingress and get load balanced across all units. Otherwise, if the provider's leader goes down, your tracing goes down.
+
+## Provider Library Usage
+
+The `TracingEndpointProvider` object may be used by charms to manage relations with their
+trace sources. For this purposes a Tempo-like charm needs to do two things
+
+1. Instantiate the `TracingEndpointProvider` object by providing it a
+reference to the parent (Tempo) charm and optionally the name of the relation that the Tempo charm
+uses to interact with its trace sources. This relation must conform to the `tracing` interface
+and it is strongly recommended that this relation be named `tracing` which is its
+default value.
+
+For example a Tempo charm may instantiate the `TracingEndpointProvider` in its constructor as
+follows
+
+    from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointProvider
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        # ...
+        self.tracing = TracingEndpointProvider(self)
+        # ...
+
+
+
+"""  # noqa: W505
+
+import enum
+import json
+import logging
+from pathlib import Path
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
+
+import pydantic
+from ops.charm import (
+    CharmBase,
+    CharmEvents,
+    RelationBrokenEvent,
+    RelationEvent,
+    RelationRole,
+)
+from ops.framework import EventSource, Object
+from ops.model import ModelError, Relation
+from pydantic import BaseModel, Field
+
+# The unique Charmhub library identifier, never change it
+LIBID = "d2f02b1f8d1244b5989fd55bc3a28943"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 11
+
+PYDEPS = ["pydantic"]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "tracing"
+RELATION_INTERFACE_NAME = "tracing"
+
+# Supported list rationale https://github.com/canonical/tempo-coordinator-k8s-operator/issues/8
+ReceiverProtocol = Literal[
+    "zipkin",
+    "otlp_grpc",
+    "otlp_http",
+    "jaeger_grpc",
+    "jaeger_thrift_http",
+]
+
+RawReceiver = Tuple[ReceiverProtocol, str]
+# Helper type. A raw receiver is defined as a tuple consisting of the protocol name, and the (external, if available),
+# (secured, if available) resolvable server url.
+
+
+BUILTIN_JUJU_KEYS = {"ingress-address", "private-address", "egress-subnets"}
+
+
+class TransportProtocolType(str, enum.Enum):
+    """Receiver Type."""
+
+    http = "http"
+    grpc = "grpc"
+
+
+receiver_protocol_to_transport_protocol: Dict[
+    ReceiverProtocol, TransportProtocolType
+] = {
+    "zipkin": TransportProtocolType.http,
+    "otlp_grpc": TransportProtocolType.grpc,
+    "otlp_http": TransportProtocolType.http,
+    "jaeger_thrift_http": TransportProtocolType.http,
+    "jaeger_grpc": TransportProtocolType.grpc,
+}
+# A mapping between telemetry protocols and their corresponding transport protocol.
+
+
+class TracingError(Exception):
+    """Base class for custom errors raised by this library."""
+
+
+class NotReadyError(TracingError):
+    """Raised by the provider wrapper if a requirer hasn't published the required data (yet)."""
+
+
+class ProtocolNotRequestedError(TracingError):
+    """Raised if the user attempts to obtain an endpoint for a protocol it did not request."""
+
+
+class DataValidationError(TracingError):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class DataAccessPermissionError(TracingError):
+    """Raised when follower units attempt leader-only operations."""
+
+
+class AmbiguousRelationUsageError(TracingError):
+    """Raised when one wrongly assumes that there can only be one relation on an endpoint."""
+
+
+if int(pydantic.version.VERSION.split(".")[0]) < 2:
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        class Config:
+            """Pydantic config."""
+
+            # ignore any extra fields in the databag
+            extra = "ignore"
+            """Ignore any extra fields in the databag."""
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                logger.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                logger.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True)
+                return databag
+
+            dct = self.dict()
+            for key, field in self.__fields__.items():  # type: ignore
+                value = dct[key]
+                databag[field.alias or key] = json.dumps(value)
+
+            return databag
+
+else:
+    from pydantic import ConfigDict
+
+    class DatabagModel(BaseModel):
+        """Base databag model."""
+
+        model_config = ConfigDict(
+            # ignore any extra fields in the databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,  # type: ignore
+        )
+        """Pydantic config."""
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")  # type: ignore
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))  # type: ignore
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.__fields__.items()}
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                logger.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.model_validate_json(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                logger.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(  # type: ignore
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
+
+            dct = self.model_dump()  # type: ignore
+            for key, field in self.model_fields.items():  # type: ignore
+                value = dct[key]
+                if value == field.default:
+                    continue
+                databag[field.alias or key] = json.dumps(value)
+
+            return databag
+
+
+# todo use models from charm-relation-interfaces
+if int(pydantic.version.VERSION.split(".")[0]) < 2:
+
+    class ProtocolType(BaseModel):  # type: ignore
+        """Protocol Type."""
+
+        class Config:
+            """Pydantic config."""
+
+            use_enum_values = True
+            """Allow serializing enum values."""
+
+        name: str = Field(
+            ...,
+            description="Receiver protocol name. What protocols are supported (and what they are called) "
+            "may differ per provider.",
+            examples=["otlp_grpc", "otlp_http", "tempo_http"],
+        )
+
+        type: TransportProtocolType = Field(
+            ...,
+            description="The transport protocol used by this receiver.",
+            examples=["http", "grpc"],
+        )
+
+else:
+
+    class ProtocolType(BaseModel):
+        """Protocol Type."""
+
+        model_config = ConfigDict(  # type: ignore
+            # Allow serializing enum values.
+            use_enum_values=True
+        )
+        """Pydantic config."""
+
+        name: str = Field(
+            ...,
+            description="Receiver protocol name. What protocols are supported (and what they are called) "
+            "may differ per provider.",
+            examples=["otlp_grpc", "otlp_http", "tempo_http"],
+        )
+
+        type: TransportProtocolType = Field(
+            ...,
+            description="The transport protocol used by this receiver.",
+            examples=["http", "grpc"],
+        )
+
+
+class Receiver(BaseModel):
+    """Specification of an active receiver."""
+
+    protocol: ProtocolType = Field(..., description="Receiver protocol name and type.")
+    url: str = Field(
+        ...,
+        description="""URL at which the receiver is reachable. If there's an ingress, it would be the external URL.
+        Otherwise, it would be the service's fqdn or internal IP.
+        If the protocol type is grpc, the url will not contain a scheme.""",
+        examples=[
+            "http://traefik_address:2331",
+            "https://traefik_address:2331",
+            "http://tempo_public_ip:2331",
+            "https://tempo_public_ip:2331",
+            "tempo_public_ip:2331",
+        ],
+    )
+
+
+class TracingProviderAppData(DatabagModel):  # noqa: D101 # type: ignore
+    """Application databag model for the tracing provider."""
+
+    receivers: List[Receiver] = Field(
+        ...,
+        description="List of all receivers enabled on the tracing provider.",
+    )
+
+
+class TracingRequirerAppData(DatabagModel):  # noqa: D101 # type: ignore
+    """Application databag model for the tracing requirer."""
+
+    receivers: List[ReceiverProtocol]
+    """Requested receivers."""
+
+
+class _AutoSnapshotEvent(RelationEvent):
+    __args__: Tuple[str, ...] = ()
+    __optional_kwargs__: Dict[str, Any] = {}
+
+    @classmethod
+    def __attrs__(cls):
+        return cls.__args__ + tuple(cls.__optional_kwargs__.keys())
+
+    def __init__(self, handle, relation, *args, **kwargs):
+        super().__init__(handle, relation)
+
+        if not len(self.__args__) == len(args):
+            raise TypeError(
+                "expected {} args, got {}".format(len(self.__args__), len(args))
+            )
+
+        for attr, obj in zip(self.__args__, args):
+            setattr(self, attr, obj)
+        for attr, default in self.__optional_kwargs__.items():
+            obj = kwargs.get(attr, default)
+            setattr(self, attr, obj)
+
+    def snapshot(self) -> dict:
+        dct = super().snapshot()
+        for attr in self.__attrs__():
+            obj = getattr(self, attr)
+            try:
+                dct[attr] = obj
+            except ValueError as e:
+                raise ValueError(
+                    "cannot automagically serialize {}: "
+                    "override this method and do it "
+                    "manually.".format(obj)
+                ) from e
+
+        return dct
+
+    def restore(self, snapshot: dict) -> None:
+        super().restore(snapshot)
+        for attr, obj in snapshot.items():
+            setattr(self, attr, obj)
+
+
+class RelationNotFoundError(Exception):
+    """Raised if no relation with the given name is found."""
+
+    def __init__(self, relation_name: str):
+        self.relation_name = relation_name
+        self.message = "No relation named '{}' found".format(relation_name)
+        super().__init__(self.message)
+
+
+class RelationInterfaceMismatchError(Exception):
+    """Raised if the relation with the given name has an unexpected interface."""
+
+    def __init__(
+        self,
+        relation_name: str,
+        expected_relation_interface: str,
+        actual_relation_interface: str,
+    ):
+        self.relation_name = relation_name
+        self.expected_relation_interface = expected_relation_interface
+        self.actual_relation_interface = actual_relation_interface
+        self.message = "The '{}' relation has '{}' as interface rather than the expected '{}'".format(
+            relation_name, actual_relation_interface, expected_relation_interface
+        )
+
+        super().__init__(self.message)
+
+
+class RelationRoleMismatchError(Exception):
+    """Raised if the relation with the given name has a different role than expected."""
+
+    def __init__(
+        self,
+        relation_name: str,
+        expected_relation_role: RelationRole,
+        actual_relation_role: RelationRole,
+    ):
+        self.relation_name = relation_name
+        self.expected_relation_interface = expected_relation_role
+        self.actual_relation_role = actual_relation_role
+        self.message = (
+            "The '{}' relation has role '{}' rather than the expected '{}'".format(
+                relation_name, repr(actual_relation_role), repr(expected_relation_role)
+            )
+        )
+
+        super().__init__(self.message)
+
+
+def _validate_relation_by_interface_and_direction(
+    charm: CharmBase,
+    relation_name: str,
+    expected_relation_interface: str,
+    expected_relation_role: RelationRole,
+):
+    """Validate a relation.
+
+    Verifies that the `relation_name` provided: (1) exists in metadata.yaml,
+    (2) declares as interface the interface name passed as `relation_interface`
+    and (3) has the right "direction", i.e., it is a relation that `charm`
+    provides or requires.
+
+    Args:
+        charm: a `CharmBase` object to scan for the matching relation.
+        relation_name: the name of the relation to be verified.
+        expected_relation_interface: the interface name to be matched by the
+            relation named `relation_name`.
+        expected_relation_role: whether the `relation_name` must be either
+            provided or required by `charm`.
+
+    Raises:
+        RelationNotFoundError: If there is no relation in the charm's metadata.yaml
+            with the same name as provided via `relation_name` argument.
+        RelationInterfaceMismatchError: The relation with the same name as provided
+            via `relation_name` argument does not have the same relation interface
+            as specified via the `expected_relation_interface` argument.
+        RelationRoleMismatchError: If the relation with the same name as provided
+            via `relation_name` argument does not have the same role as specified
+            via the `expected_relation_role` argument.
+    """
+    if relation_name not in charm.meta.relations:
+        raise RelationNotFoundError(relation_name)
+
+    relation = charm.meta.relations[relation_name]
+
+    # fixme: why do we need to cast here?
+    actual_relation_interface = cast(str, relation.interface_name)
+
+    if actual_relation_interface != expected_relation_interface:
+        raise RelationInterfaceMismatchError(
+            relation_name, expected_relation_interface, actual_relation_interface
+        )
+
+    if expected_relation_role is RelationRole.provides:
+        if relation_name not in charm.meta.provides:
+            raise RelationRoleMismatchError(
+                relation_name, RelationRole.provides, RelationRole.requires
+            )
+    elif expected_relation_role is RelationRole.requires:
+        if relation_name not in charm.meta.requires:
+            raise RelationRoleMismatchError(
+                relation_name, RelationRole.requires, RelationRole.provides
+            )
+    else:
+        raise TypeError(
+            "Unexpected RelationDirection: {}".format(expected_relation_role)
+        )
+
+
+class RequestEvent(RelationEvent):
+    """Event emitted when a remote requests a tracing endpoint."""
+
+    @property
+    def requested_receivers(self) -> List[ReceiverProtocol]:
+        """List of receiver protocols that have been requested."""
+        relation = self.relation
+        app = relation.app
+        if not app:
+            raise NotReadyError("relation.app is None")
+
+        return TracingRequirerAppData.load(relation.data[app]).receivers
+
+
+class BrokenEvent(RelationBrokenEvent):
+    """Event emitted when a relation on tracing is broken."""
+
+
+class TracingEndpointProviderEvents(CharmEvents):
+    """TracingEndpointProvider events."""
+
+    request = EventSource(RequestEvent)
+    broken = EventSource(BrokenEvent)
+
+
+class TracingEndpointProvider(Object):
+    """Class representing a trace receiver service."""
+
+    on = TracingEndpointProviderEvents()  # type: ignore
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        external_url: Optional[str] = None,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Initialize.
+
+        Args:
+            charm: a `CharmBase` instance that manages this instance of the Tempo service.
+            external_url: external address of the node hosting the tempo server,
+                if an ingress is present.
+            relation_name: an optional string name of the relation between `charm`
+                and the Tempo charmed service. The default is "tracing".
+
+        Raises:
+            RelationNotFoundError: If there is no relation in the charm's metadata.yaml
+                with the same name as provided via `relation_name` argument.
+            RelationInterfaceMismatchError: The relation with the same name as provided
+                via `relation_name` argument does not have the `tracing` relation
+                interface.
+            RelationRoleMismatchError: If the relation with the same name as provided
+                via `relation_name` argument does not have the `RelationRole.requires`
+                role.
+        """
+        _validate_relation_by_interface_and_direction(
+            charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.provides
+        )
+
+        super().__init__(charm, relation_name + "tracing-provider")
+        self._charm = charm
+        self._external_url = external_url
+        self._relation_name = relation_name
+        self.framework.observe(
+            self._charm.on[relation_name].relation_joined, self._on_relation_event
+        )
+        self.framework.observe(
+            self._charm.on[relation_name].relation_created, self._on_relation_event
+        )
+        self.framework.observe(
+            self._charm.on[relation_name].relation_changed, self._on_relation_event
+        )
+        self.framework.observe(
+            self._charm.on[relation_name].relation_broken,
+            self._on_relation_broken_event,
+        )
+
+    def _on_relation_broken_event(self, e: RelationBrokenEvent):
+        """Handle relation broken events."""
+        self.on.broken.emit(e.relation)
+
+    def _on_relation_event(self, e: RelationEvent):
+        """Handle relation created/joined/changed events."""
+        if self.is_requirer_ready(e.relation):
+            self.on.request.emit(e.relation)
+
+    def is_requirer_ready(self, relation: Relation):
+        """Attempt to determine if requirer has already populated app data."""
+        try:
+            self._get_requested_protocols(relation)
+        except NotReadyError:
+            return False
+        return True
+
+    @staticmethod
+    def _get_requested_protocols(relation: Relation):
+        app = relation.app
+        if not app:
+            raise NotReadyError("relation.app is None")
+
+        try:
+            databag = TracingRequirerAppData.load(relation.data[app])
+        except (json.JSONDecodeError, pydantic.ValidationError, DataValidationError):
+            logger.info("relation %s is not ready to talk tracing", relation)
+            raise NotReadyError()
+        return databag.receivers
+
+    def requested_protocols(self):
+        """All receiver protocols that have been requested by our related apps."""
+        requested_protocols = set()
+        for relation in self.relations:
+            try:
+                protocols = self._get_requested_protocols(relation)
+            except NotReadyError:
+                continue
+            requested_protocols.update(protocols)
+        return requested_protocols
+
+    @property
+    def relations(self) -> List[Relation]:
+        """All relations active on this endpoint."""
+        return self._charm.model.relations[self._relation_name]
+
+    def publish_receivers(self, receivers: Sequence[RawReceiver]):
+        """Let all requirers know that these receivers are active and listening."""
+        if not self._charm.unit.is_leader():
+            raise RuntimeError("only leader can do this")
+
+        for relation in self.relations:
+            try:
+                TracingProviderAppData(
+                    receivers=[
+                        Receiver(
+                            url=url,
+                            protocol=ProtocolType(
+                                name=protocol,
+                                type=receiver_protocol_to_transport_protocol[protocol],
+                            ),
+                        )
+                        for protocol, url in receivers
+                    ],
+                ).dump(relation.data[self._charm.app])
+
+            except ModelError as e:
+                # args are bytes
+                msg = e.args[0]
+                if isinstance(msg, bytes):
+                    if msg.startswith(
+                        b"ERROR cannot read relation application settings: permission denied"
+                    ):
+                        logger.error(
+                            "encountered error %s while attempting to update_relation_data."
+                            "The relation must be gone.",
+                            e,
+                        )
+                        continue
+                raise
+
+
+class EndpointRemovedEvent(RelationBrokenEvent):
+    """Event representing a change in one of the receiver endpoints."""
+
+
+class EndpointChangedEvent(_AutoSnapshotEvent):
+    """Event representing a change in one of the receiver endpoints."""
+
+    __args__ = ("_receivers",)
+
+    if TYPE_CHECKING:
+        _receivers = []  # type: List[dict]
+
+    @property
+    def receivers(self) -> List[Receiver]:
+        """Cast receivers back from dict."""
+        return [Receiver(**i) for i in self._receivers]
+
+
+class TracingEndpointRequirerEvents(CharmEvents):
+    """TracingEndpointRequirer events."""
+
+    endpoint_changed = EventSource(EndpointChangedEvent)
+    endpoint_removed = EventSource(EndpointRemovedEvent)
+
+
+class TracingEndpointRequirer(Object):
+    """A tracing endpoint for Tempo."""
+
+    on = TracingEndpointRequirerEvents()  # type: ignore
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        protocols: Optional[List[ReceiverProtocol]] = None,
+    ):
+        """Construct a tracing requirer for a Tempo charm.
+
+        If your application supports pushing traces to a distributed tracing backend, the
+        `TracingEndpointRequirer` object enables your charm to easily access endpoint information
+        exchanged over a `tracing` relation interface.
+
+        Args:
+            charm: a `CharmBase` object that manages this
+                `TracingEndpointRequirer` object. Typically, this is `self` in the instantiating
+                class.
+            relation_name: an optional string name of the relation between `charm`
+                and the Tempo charmed service. The default is "tracing". It is strongly
+                advised not to change the default, so that people deploying your charm will have a
+                consistent experience with all other charms that provide tracing endpoints.
+            protocols: optional list of protocols that the charm intends to send traces with.
+                The provider will enable receivers for these and only these protocols,
+                so be sure to enable all protocols the charm or its workload are going to need.
+
+        Raises:
+            RelationNotFoundError: If there is no relation in the charm's metadata.yaml
+                with the same name as provided via `relation_name` argument.
+            RelationInterfaceMismatchError: The relation with the same name as provided
+                via `relation_name` argument does not have the `tracing` relation
+                interface.
+            RelationRoleMismatchError: If the relation with the same name as provided
+                via `relation_name` argument does not have the `RelationRole.provides`
+                role.
+        """
+        _validate_relation_by_interface_and_direction(
+            charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.requires
+        )
+
+        super().__init__(charm, relation_name)
+
+        self._is_single_endpoint = charm.meta.relations[relation_name].limit == 1
+
+        self._charm = charm
+        self._relation_name = relation_name
+
+        events = self._charm.on[self._relation_name]
+        self.framework.observe(
+            events.relation_changed, self._on_tracing_relation_changed
+        )
+        self.framework.observe(events.relation_broken, self._on_tracing_relation_broken)
+
+        if protocols and self._charm.unit.is_leader():
+            # we can't be sure that the current event context supports read/writing relation data for this relation,
+            # so we catch ModelErrors. This is because we're doing this in init.
+            try:
+                self.request_protocols(protocols)
+            except ModelError as e:
+                logger.error(
+                    "encountered error %s while attempting to request_protocols."
+                    "The relation must be gone.",
+                    e,
+                )
+                pass
+
+    def request_protocols(
+        self, protocols: Sequence[ReceiverProtocol], relation: Optional[Relation] = None
+    ):
+        """Publish the list of protocols which the provider should activate."""
+        # todo: should we check if _is_single_endpoint and len(self.relations) > 1 and raise, here?
+        relations = [relation] if relation else self.relations
+
+        if not protocols:
+            # empty sequence
+            raise ValueError(
+                "You need to pass a nonempty sequence of protocols to `request_protocols`."
+            )
+
+        if self._charm.unit.is_leader():
+            for relation in relations:
+                TracingRequirerAppData(
+                    receivers=list(protocols),
+                ).dump(relation.data[self._charm.app])
+        else:
+            raise DataAccessPermissionError("only leaders can request_protocols")
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The tracing relations associated with this endpoint."""
+        return self._charm.model.relations[self._relation_name]
+
+    @property
+    def _relation(self) -> Optional[Relation]:
+        """If this wraps a single endpoint, the relation bound to it, if any."""
+        if not self._is_single_endpoint:
+            objname = type(self).__name__
+            raise AmbiguousRelationUsageError(
+                f"This {objname} wraps a {self._relation_name} endpoint that has "
+                "limit != 1. We can't determine what relation, of the possibly many, you are "
+                f"talking about. Please pass a relation instance while calling {objname}, "
+                "or set limit=1 in the charm metadata."
+            )
+        relations = self.relations
+        return relations[0] if relations else None
+
+    def is_ready(self, relation: Optional[Relation] = None):
+        """Is this endpoint ready?"""
+        relation = relation or self._relation
+        if not relation:
+            logger.debug("no relation on %r: tracing not ready", self._relation_name)
+            return False
+        if relation.data is None:
+            logger.error("relation data is None for %s", relation)
+            return False
+        if not relation.app:
+            logger.error("%s event received but there is no relation.app", relation)
+            return False
+        try:
+            databag = dict(relation.data[relation.app])
+            TracingProviderAppData.load(databag)
+
+        except (json.JSONDecodeError, pydantic.ValidationError, DataValidationError):
+            logger.info("failed validating relation data for %s", relation)
+            return False
+        return True
+
+    def _on_tracing_relation_changed(self, event):
+        """Notify the providers that there is new endpoint information available."""
+        relation = event.relation
+        if not self.is_ready(relation):
+            self.on.endpoint_removed.emit(relation)  # type: ignore
+            return
+
+        data = TracingProviderAppData.load(relation.data[relation.app])
+        self.on.endpoint_changed.emit(relation, [i.dict() for i in data.receivers])  # type: ignore
+
+    def _on_tracing_relation_broken(self, event: RelationBrokenEvent):
+        """Notify the providers that the endpoint is broken."""
+        relation = event.relation
+        self.on.endpoint_removed.emit(relation)  # type: ignore
+
+    def get_all_endpoints(
+        self, relation: Optional[Relation] = None
+    ) -> Optional[TracingProviderAppData]:
+        """Unmarshalled relation data."""
+        relation = relation or self._relation
+        if not self.is_ready(relation):
+            return
+        return TracingProviderAppData.load(relation.data[relation.app])  # type: ignore
+
+    def _get_endpoint(
+        self, relation: Optional[Relation], protocol: ReceiverProtocol
+    ) -> Optional[str]:
+        app_data = self.get_all_endpoints(relation)
+        if not app_data:
+            return None
+        receivers: List[Receiver] = list(
+            filter(lambda i: i.protocol.name == protocol, app_data.receivers)
+        )
+        if not receivers:
+            # it can happen if the charm requests tracing protocols, but the relay (such as grafana-agent) isn't yet
+            # connected to the tracing backend. In this case, it's not an error the charm author can do anything about
+            logger.warning("no receiver found with protocol=%r.", protocol)
+            return
+        if len(receivers) > 1:
+            # if we have more than 1 receiver that matches, it shouldn't matter which receiver we'll be using.
+            logger.warning(
+                "too many receivers with protocol=%r; using first one. Found: %s",
+                protocol,
+                receivers,
+            )
+
+        receiver = receivers[0]
+        return receiver.url
+
+    def get_endpoint(
+        self, protocol: ReceiverProtocol, relation: Optional[Relation] = None
+    ) -> Optional[str]:
+        """Receiver endpoint for the given protocol.
+
+        It could happen that this function gets called before the provider publishes the endpoints.
+        In such a scenario, if a non-leader unit calls this function, a permission denied exception will be raised due to
+        restricted access. To prevent this, this function needs to be guarded by the `is_ready` check.
+
+        Raises:
+        ProtocolNotRequestedError:
+            If the charm unit is the leader unit and attempts to obtain an endpoint for a protocol it did not request.
+        """
+        endpoint = self._get_endpoint(relation or self._relation, protocol=protocol)
+        if not endpoint:
+            requested_protocols = set()
+            relations = [relation] if relation else self.relations
+            for relation in relations:
+                try:
+                    databag = TracingRequirerAppData.load(
+                        relation.data[self._charm.app]
+                    )
+                except DataValidationError:
+                    continue
+
+                requested_protocols.update(databag.receivers)
+
+            if protocol not in requested_protocols:
+                raise ProtocolNotRequestedError(protocol, relation)
+
+            return None
+        return endpoint
+
+
+def charm_tracing_config(
+    endpoint_requirer: TracingEndpointRequirer, cert_path: Optional[Union[Path, str]]
+) -> Tuple[Optional[str], Optional[str]]:
+    """Return the charm_tracing config you likely want.
+
+    If no endpoint is provided:
+     disable charm tracing.
+    If https endpoint is provided but cert_path is not found on disk:
+     disable charm tracing.
+    If https endpoint is provided and cert_path is None:
+     ERROR
+    Else:
+     proceed with charm tracing (with or without tls, as appropriate)
+
+    Usage:
+    >>> from lib.charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
+    >>> from lib.charms.tempo_coordinator_k8s.v0.tracing import charm_tracing_config
+    >>> @trace_charm(tracing_endpoint="my_endpoint", cert_path="cert_path")
+    >>> class MyCharm(...):
+    >>>     _cert_path = "/path/to/cert/on/charm/container.crt"
+    >>>     def __init__(self, ...):
+    >>>         self.tracing = TracingEndpointRequirer(...)
+    >>>         self.my_endpoint, self.cert_path = charm_tracing_config(
+    ...             self.tracing, self._cert_path)
+    """
+    if not endpoint_requirer.is_ready():
+        return None, None
+
+    try:
+        endpoint = endpoint_requirer.get_endpoint("otlp_http")
+    except ModelError as e:
+        if e.args[0] == "ERROR permission denied\n":
+            # this can happen the app databag doesn't have data,
+            # or we're breaking the relation.
+            return None, None
+        raise
+
+    if not endpoint:
+        return None, None
+
+    is_https = endpoint.startswith("https://")
+
+    if is_https:
+        if cert_path is None or not Path(cert_path).exists():
+            # disable charm tracing until we obtain a cert to prevent tls errors
+            logger.error(
+                "Tracing endpoint is https, but no server_cert has been passed."
+                "Please point @trace_charm to a `server_cert` attr. "
+                "This might also mean that the tracing provider is related to a "
+                "certificates provider, but this application is not (yet). "
+                "In that case, you might just have to wait a bit for the certificates "
+                "integration to settle. "
+            )
+            return None, None
+        return endpoint, str(cert_path)
+    else:
+        return endpoint, None

--- a/src/charm.py
+++ b/src/charm.py
@@ -198,14 +198,16 @@ class JujuControllerCharm(CharmBase):
             return
 
         self._stored.tracing_endpoints = {
-            "grpc": self.tracing_requirer.get_endpoint("otlp_grpc", event.relation),
-            "http": self.tracing_requirer.get_endpoint("otlp_http", event.relation),
+            "otlp_grpc": self.tracing_requirer.get_endpoint("otlp_grpc", event.relation),
+            "otlp_http": self.tracing_requirer.get_endpoint("otlp_http", event.relation),
         }
         logger.info("tracing endpoints updated: %s", self._stored.tracing_endpoints)
+        self._update_charm_tracing_config()
 
     def _on_tracing_relation_removed(self, event):
         self._stored.tracing_endpoints = {}
         logger.info("tracing endpoints cleared")
+        self._update_charm_tracing_config()
 
     def _on_receive_ca_cert_updated(self, event):
         ca_list = event.certificates
@@ -214,10 +216,12 @@ class JujuControllerCharm(CharmBase):
 
         self._stored.ca_cert = '\n'.join(sorted(ca_list))
         logger.info("CA certificate updated from relation id %s", event.relation_id)
+        self._update_charm_tracing_config()
 
     def _on_receive_ca_cert_removed(self, event):
         self._stored.ca_cert = None
         logger.info("CA certificate removed from relation id %s", event.relation_id)
+        self._update_charm_tracing_config()
 
     def _update_bind_addresses(self, relation):
         """Maintain our own bind address in relation data.
@@ -332,6 +336,22 @@ class JujuControllerCharm(CharmBase):
     def _request_config_reload(self):
         """Send a reload request to the config reload socket."""
         self._config_change_socket.reload_config()
+
+    def _update_charm_tracing_config(self):
+        """Update charm configuration with current tracing endpoint and CA cert information."""
+        self._control_socket.set_charm_tracing_config(
+            grpc_endpoint=(
+                self._stored.tracing_endpoints["otlp_grpc"]
+                if "otlp_grpc" in self._stored.tracing_endpoints
+                else None
+            ),
+            http_endpoint=(
+                self._stored.tracing_endpoints["otlp_http"]
+                if "otlp_http" in self._stored.tracing_endpoints
+                else None
+            ),
+            ca_cert=self._stored.ca_cert,
+        )
 
 
 def metrics_username(relation: Relation) -> str:

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,6 +12,9 @@ import yaml
 
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer
+from charms.certificate_transfer_interface.v1.certificate_transfer import (
+    CertificateTransferRequires,
+)
 from ops.charm import CharmBase, CollectStatusEvent
 from ops.framework import StoredState
 from ops.charm import InstallEvent, RelationJoinedEvent, RelationDepartedEvent
@@ -38,10 +41,14 @@ class JujuControllerCharm(CharmBase):
         self.tracing_requirer = TracingEndpointRequirer(
             self, protocols=["otlp_http", "otlp_grpc"]
         )
+        self._certificate_transfer = CertificateTransferRequires(
+            self, relationship_name='receive-ca-cert'
+        )
 
         self._stored.set_default(
             last_bind_addresses=[],
             tracing_endpoints={},
+            ca_cert=None,
         )
 
         # TODO (manadart 2024-03-05): Get these at need.
@@ -74,6 +81,12 @@ class JujuControllerCharm(CharmBase):
             self.tracing_requirer.on.endpoint_changed, self._on_tracing_relation_changed)
         self.framework.observe(
             self.tracing_requirer.on.endpoint_removed, self._on_tracing_relation_removed)
+        self.framework.observe(
+            self._certificate_transfer.on.certificate_set_updated,
+            self._on_receive_ca_cert_updated,
+        )
+        self.framework.observe(
+            self._certificate_transfer.on.certificates_removed, self._on_receive_ca_cert_removed)
 
     def _on_install(self, event: InstallEvent):
         """Ensure that the controller configuration file exists."""
@@ -193,6 +206,18 @@ class JujuControllerCharm(CharmBase):
     def _on_tracing_relation_removed(self, event):
         self._stored.tracing_endpoints = {}
         logger.info("tracing endpoints cleared")
+
+    def _on_receive_ca_cert_updated(self, event):
+        ca_list = event.certificates
+        if not ca_list:
+            return
+
+        self._stored.ca_cert = '\n'.join(sorted(ca_list))
+        logger.info("CA certificate updated from relation id %s", event.relation_id)
+
+    def _on_receive_ca_cert_removed(self, event):
+        self._stored.ca_cert = None
+        logger.info("CA certificate removed from relation id %s", event.relation_id)
 
     def _update_bind_addresses(self, relation):
         """Maintain our own bind address in relation data.
@@ -335,5 +360,4 @@ class DBBindAddressException(Exception):
 
 
 if __name__ == "__main__":
-
     main(JujuControllerCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,6 +11,7 @@ import urllib.parse
 import yaml
 
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
+from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer
 from ops.charm import CharmBase, CollectStatusEvent
 from ops.framework import StoredState
 from ops.charm import InstallEvent, RelationJoinedEvent, RelationDepartedEvent
@@ -34,18 +35,23 @@ class JujuControllerCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
-        self._observe()
+        self.tracing_requirer = TracingEndpointRequirer(
+            self, protocols=["otlp_http", "otlp_grpc"]
+        )
 
         self._stored.set_default(
             last_bind_addresses=[],
+            tracing_endpoints={},
         )
 
         # TODO (manadart 2024-03-05): Get these at need.
-        # No need to instantiate them for every invocatoin.
+        # No need to instantiate them for every invocation.
         self._control_socket = controlsocket.ControlSocketClient(
             socket_path=self.METRICS_SOCKET_PATH)
         self._config_change_socket = configchangesocket.ConfigChangeSocketClient(
             socket_path=self.CONFIG_SOCKET_PATH)
+
+        self._observe()
 
     def _observe(self):
         """Set up all framework event observers."""
@@ -64,6 +70,10 @@ class JujuControllerCharm(CharmBase):
             self.on.dbcluster_relation_changed, self._on_dbcluster_relation_changed)
         self.framework.observe(
             self.on.dbcluster_relation_departed, self._on_dbcluster_relation_departed)
+        self.framework.observe(
+            self.tracing_requirer.on.endpoint_changed, self._on_tracing_relation_changed)
+        self.framework.observe(
+            self.tracing_requirer.on.endpoint_removed, self._on_tracing_relation_removed)
 
     def _on_install(self, event: InstallEvent):
         """Ensure that the controller configuration file exists."""
@@ -169,6 +179,20 @@ class JujuControllerCharm(CharmBase):
     def _on_dbcluster_relation_departed(self, event):
         relation = event.relation
         self._update_bind_addresses(relation)
+
+    def _on_tracing_relation_changed(self, event):
+        if not self.tracing_requirer.is_ready(event.relation):
+            return
+
+        self._stored.tracing_endpoints = {
+            "grpc": self.tracing_requirer.get_endpoint("otlp_grpc", event.relation),
+            "http": self.tracing_requirer.get_endpoint("otlp_http", event.relation),
+        }
+        logger.info("tracing endpoints updated: %s", self._stored.tracing_endpoints)
+
+    def _on_tracing_relation_removed(self, event):
+        self._stored.tracing_endpoints = {}
+        logger.info("tracing endpoints cleared")
 
     def _update_bind_addresses(self, relation):
         """Maintain our own bind address in relation data.

--- a/src/controlsocket.py
+++ b/src/controlsocket.py
@@ -32,3 +32,22 @@ class ControlSocketClient(unixsocket.SocketClient):
             path=f'/metrics-users/{username}',
         )
         logger.debug('result of remove_metrics_user request: %r', resp)
+
+    def set_charm_tracing_config(
+        self,
+        grpc_endpoint: Optional[str],
+        http_endpoint: Optional[str],
+        ca_cert: Optional[str],
+    ):
+        """Set the tracing configuration for the charm."""
+        body = {
+            "grpc_endpoint": grpc_endpoint,
+            "http_endpoint": http_endpoint,
+            "ca_cert": ca_cert,
+        }
+        resp = self.json_request(
+            method='POST',
+            path='/charm-tracing-config',
+            body=body,
+        )
+        logger.debug('result of set_charm_tracing_config request: %r', resp)

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -8,6 +8,9 @@ import unittest
 
 import yaml
 
+from charms.certificate_transfer_interface.v1.certificate_transfer import (
+    ProviderApplicationData,
+)
 from charms.tempo_coordinator_k8s.v0.tracing import (
     ProtocolType,
     Receiver,
@@ -61,6 +64,10 @@ def tracing_provider_data():
             ),
         ]
     ).dump()
+
+
+def certificate_provider_data(certificates):
+    return ProviderApplicationData(certificates=certificates).dump()
 
 
 class TestCharm(unittest.TestCase):
@@ -171,6 +178,42 @@ class TestCharm(unittest.TestCase):
         harness.remove_relation(relation_id)
 
         self.assertEqual(harness.charm._stored.tracing_endpoints, {})
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    def test_receive_ca_cert_updates_stored_ca_cert(self, *_):
+        harness = self.harness
+
+        relation_id = harness.add_relation("receive-ca-cert", "cert-provider")
+        harness.add_relation_unit(relation_id, "cert-provider/0")
+
+        cert_a = "-----BEGIN CERTIFICATE-----\na\n-----END CERTIFICATE-----"
+        cert_b = "-----BEGIN CERTIFICATE-----\nb\n-----END CERTIFICATE-----"
+        harness.update_relation_data(
+            relation_id,
+            "cert-provider",
+            certificate_provider_data({cert_b, cert_a}),
+        )
+
+        self.assertEqual(harness.charm._stored.ca_cert, "\n".join([cert_a, cert_b]))
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    def test_receive_ca_cert_removed_clears_stored_ca_cert(self, *_):
+        harness = self.harness
+
+        relation_id = harness.add_relation("receive-ca-cert", "cert-provider")
+        harness.add_relation_unit(relation_id, "cert-provider/0")
+
+        cert = "-----BEGIN CERTIFICATE-----\na\n-----END CERTIFICATE-----"
+        harness.update_relation_data(
+            relation_id,
+            "cert-provider",
+            certificate_provider_data({cert}),
+        )
+        self.assertEqual(harness.charm._stored.ca_cert, cert)
+
+        harness.remove_relation(relation_id)
+
+        self.assertIsNone(harness.charm._stored.ca_cert)
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf_apiaddresses_missing)
     def test_apiaddresses_missing(self, _):

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -8,6 +8,12 @@ import unittest
 
 import yaml
 
+from charms.tempo_coordinator_k8s.v0.tracing import (
+    ProtocolType,
+    Receiver,
+    TracingProviderAppData,
+    TransportProtocolType,
+)
 from charm import JujuControllerCharm, AgentConfException
 from ops.model import BlockedStatus, ActiveStatus
 from ops.testing import Harness
@@ -40,6 +46,21 @@ apiaddresses:
 - "[::1]:17070"
 cacert: fake
 '''
+
+
+def tracing_provider_data():
+    return TracingProviderAppData(
+        receivers=[
+            Receiver(
+                protocol=ProtocolType(name="otlp_grpc", type=TransportProtocolType.grpc),
+                url="tempo-grpc:4317",
+            ),
+            Receiver(
+                protocol=ProtocolType(name="otlp_http", type=TransportProtocolType.http),
+                url="http://tempo-http:4318",
+            ),
+        ]
+    ).dump()
 
 
 class TestCharm(unittest.TestCase):
@@ -116,6 +137,41 @@ class TestCharm(unittest.TestCase):
         harness.remove_relation(relation_id)
         mock_remove_user.assert_called_once_with(f'juju-metrics-r{relation_id}')
 
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    def test_tracing_relation_updates_endpoints(self, *_):
+        harness = self.harness
+
+        relation_id = harness.add_relation("tracing", "tempo-coordinator")
+        harness.add_relation_unit(relation_id, "tempo-coordinator/0")
+
+        provider_data = tracing_provider_data()
+
+        harness.update_relation_data(relation_id, "tempo-coordinator", provider_data)
+
+        self.assertEqual(
+            harness.charm._stored.tracing_endpoints,
+            {"grpc": "tempo-grpc:4317", "http": "http://tempo-http:4318"},
+        )
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    def test_tracing_relation_removed_clears_endpoints(self, *_):
+        harness = self.harness
+
+        relation_id = harness.add_relation("tracing", "tempo-coordinator")
+        harness.add_relation_unit(relation_id, "tempo-coordinator/0")
+
+        harness.update_relation_data(
+            relation_id, "tempo-coordinator", tracing_provider_data()
+        )
+        self.assertEqual(
+            harness.charm._stored.tracing_endpoints,
+            {"grpc": "tempo-grpc:4317", "http": "http://tempo-http:4318"},
+        )
+
+        harness.remove_relation(relation_id)
+
+        self.assertEqual(harness.charm._stored.tracing_endpoints, {})
+
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf_apiaddresses_missing)
     def test_apiaddresses_missing(self, _):
         harness = self.harness
@@ -172,7 +228,7 @@ class TestCharm(unittest.TestCase):
 
         # Have another unit enter the relation.
         # Its bind address should end up in the application data bindings list.
-        # Note that the agent ID doesn not correspond with the unit's ID
+        # Note that the agent ID does not correspond with the unit's ID
         relation_id = harness.add_relation('dbcluster', harness.charm.app.name)
         harness.add_relation_unit(relation_id, 'juju-controller/1')
         self.harness.update_relation_data(
@@ -251,7 +307,8 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(yaml.safe_load(written), {'db-bind-addresses': bound})
 
-        # The last thing we should have done is send a reload request via the socket..
+        # The last thing we should have done is send a reload request via the
+        # socket..
         mock_reload_config.assert_called_once()
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -21,6 +21,7 @@ from charm import JujuControllerCharm, AgentConfException
 from ops.model import BlockedStatus, ActiveStatus
 from ops.testing import Harness
 from unittest.mock import mock_open, patch
+from unixsocket import ConnectionError as SocketConnectionError
 
 agent_conf = '''
 apiaddresses:
@@ -145,7 +146,8 @@ class TestCharm(unittest.TestCase):
         mock_remove_user.assert_called_once_with(f'juju-metrics-r{relation_id}')
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
-    def test_tracing_relation_updates_endpoints(self, *_):
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    def test_tracing_relation_updates_endpoints(self, mock_set_tracing_config, *_):
         harness = self.harness
 
         relation_id = harness.add_relation("tracing", "tempo-coordinator")
@@ -157,11 +159,49 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             harness.charm._stored.tracing_endpoints,
-            {"grpc": "tempo-grpc:4317", "http": "http://tempo-http:4318"},
+            {"otlp_grpc": "tempo-grpc:4317", "otlp_http": "http://tempo-http:4318"},
+        )
+        mock_set_tracing_config.assert_called_once_with(
+            grpc_endpoint="tempo-grpc:4317",
+            http_endpoint="http://tempo-http:4318",
+            ca_cert=None,
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
-    def test_tracing_relation_removed_clears_endpoints(self, *_):
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    def test_tracing_relation_change_ignores_not_ready(
+        self, mock_set_tracing_config, *_
+    ):
+        harness = self.harness
+
+        event = type("Event", (), {"relation": object()})()
+        with patch.object(harness.charm.tracing_requirer, "is_ready", return_value=False):
+            harness.charm._on_tracing_relation_changed(event)
+
+        self.assertEqual(harness.charm._stored.tracing_endpoints, {})
+        mock_set_tracing_config.assert_not_called()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch(
+        "controlsocket.ControlSocketClient.set_charm_tracing_config",
+        side_effect=SocketConnectionError("could not connect to socket"),
+    )
+    def test_tracing_relation_update_propagates_socket_error(self, *_):
+        harness = self.harness
+
+        relation_id = harness.add_relation("tracing", "tempo-coordinator")
+        harness.add_relation_unit(relation_id, "tempo-coordinator/0")
+
+        with self.assertRaisesRegex(
+            SocketConnectionError, "could not connect to socket"
+        ):
+            harness.update_relation_data(
+                relation_id, "tempo-coordinator", tracing_provider_data()
+            )
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    def test_tracing_relation_removed_clears_endpoints(self, mock_set_tracing_config, *_):
         harness = self.harness
 
         relation_id = harness.add_relation("tracing", "tempo-coordinator")
@@ -172,15 +212,27 @@ class TestCharm(unittest.TestCase):
         )
         self.assertEqual(
             harness.charm._stored.tracing_endpoints,
-            {"grpc": "tempo-grpc:4317", "http": "http://tempo-http:4318"},
+            {"otlp_grpc": "tempo-grpc:4317", "otlp_http": "http://tempo-http:4318"},
+        )
+        mock_set_tracing_config.assert_called_once_with(
+            grpc_endpoint="tempo-grpc:4317",
+            http_endpoint="http://tempo-http:4318",
+            ca_cert=None,
         )
 
         harness.remove_relation(relation_id)
 
         self.assertEqual(harness.charm._stored.tracing_endpoints, {})
+        self.assertEqual(mock_set_tracing_config.call_count, 2)
+        mock_set_tracing_config.assert_called_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=None,
+        )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
-    def test_receive_ca_cert_updates_stored_ca_cert(self, *_):
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    def test_receive_ca_cert_updates_stored_ca_cert(self, mock_set_tracing_config, *_):
         harness = self.harness
 
         relation_id = harness.add_relation("receive-ca-cert", "cert-provider")
@@ -195,9 +247,28 @@ class TestCharm(unittest.TestCase):
         )
 
         self.assertEqual(harness.charm._stored.ca_cert, "\n".join([cert_a, cert_b]))
+        mock_set_tracing_config.assert_called_once_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert="\n".join([cert_a, cert_b]),
+        )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
-    def test_receive_ca_cert_removed_clears_stored_ca_cert(self, *_):
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    def test_receive_ca_cert_update_ignores_empty_cert_list(
+        self, mock_set_tracing_config, *_
+    ):
+        harness = self.harness
+
+        event = type("Event", (), {"certificates": set(), "relation_id": 1})()
+        harness.charm._on_receive_ca_cert_updated(event)
+
+        self.assertIsNone(harness.charm._stored.ca_cert)
+        mock_set_tracing_config.assert_not_called()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    def test_receive_ca_cert_removed_clears_stored_ca_cert(self, mock_set_tracing_config, *_):
         harness = self.harness
 
         relation_id = harness.add_relation("receive-ca-cert", "cert-provider")
@@ -210,10 +281,21 @@ class TestCharm(unittest.TestCase):
             certificate_provider_data({cert}),
         )
         self.assertEqual(harness.charm._stored.ca_cert, cert)
+        mock_set_tracing_config.assert_called_once_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=cert,
+        )
 
         harness.remove_relation(relation_id)
 
         self.assertIsNone(harness.charm._stored.ca_cert)
+        self.assertEqual(mock_set_tracing_config.call_count, 2)
+        mock_set_tracing_config.assert_called_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=None,
+        )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf_apiaddresses_missing)
     def test_apiaddresses_missing(self, _):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -89,6 +89,30 @@ class TestClass(unittest.TestCase):
         self.assertEqual(cm.exception.status, '')
         self.assertEqual(cm.exception.message, 'user "juju-metrics-r0" not found')
 
+    def test_set_charm_tracing_config_success(self):
+        mock_opener = MockOpener(self)
+        control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
+
+        mock_opener.expect(
+            url='http://localhost/charm-tracing-config',
+            method='POST',
+            body=(
+                r'{"grpc_endpoint": "grpc://trace.example.com:4317", '
+                r'"http_endpoint": "http://trace.example.com:4318", '
+                r'"ca_cert": "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----"}'
+            ),
+            response=MockResponse(
+                headers=MockHeaders(content_type='application/json'),
+                body=r'{"message":"updated charm tracing config"}'
+            )
+        )
+
+        control_socket.set_charm_tracing_config(
+            grpc_endpoint='grpc://trace.example.com:4317',
+            http_endpoint='http://trace.example.com:4318',
+            ca_cert='-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----',
+        )
+
     def test_connection_error(self):
         mock_opener = MockOpener(self)
         control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)


### PR DESCRIPTION
Integrates both `tracing` and `certificate_transfer` providers with the controller charm. This allows the controller charm to capture both the http and grpc endpoints, along with the certificate for https requests. The information will then be passed to the agent via controlsocket for storing in the database. Ultimately, the captured data will then be passed as hook envvars to each charm, thus removing the need for multiple CMR integrations to a tempo collector.

A lot of the work was already done for metric users, so it was a case of riffing off of that for the tempo integration.

## QA Steps

### Setup Tempo

Build the charm with `charmcraft pack`

To make this proper, we need a COS-lite or something similar. I used [COS-lite on microk8s](https://documentation.ubuntu.com/observability/track-2/tutorial/installation/cos-lite-microk8s-sandbox/) and then deployed [tempo](https://documentation.ubuntu.com/observability/track-2/how-to/add-tracing-to-cos-lite/) in the same model.

Once there is a COS-lite with tempo we need to offer the `tempo:tracing` relation.

```sh
$ juju offer tempo:tracing
```

### Controller charm setup

To make this "simple" we can only deploy a local controller charm using IAAS controllers. So we need to bootstrap a IAAS controller (again for simplicity I'm using LXD).

```sh
$ juju bootstrap lxd test --bootstrap-base=ubuntu@24.04 --controller-charm-path=./juju-controller_ubuntu@24.04-amd64.charm
$ juju switch controller
$ juju consume cos:admin/lite.tempo
$ juju integrate controller:tracing tempo:tracing
```

### Verify the endpoints are consumed

```sh
$ juju ssh -m test:controller controller 0
$ juju_db_repl
repl (controller)> SELECT * FROM charm_tracing_config
key             value
http-endpoint   http://tempo.m.svc.cluster.local:4318
grpc-endpoint   tempo.m.svc.cluster.local:4317
```

### Verify that the information is set as vars:

```sh
$ juju debug-hook -m controller controller/0
```

You might have to trigger a hook invocation with something like `juju config -m controller controller identity-provider-url="foo"`.

```sh
root@juju-2bd818-0:/var/lib/juju/agents/unit-controller-0/charm# printenv | grep -E "JUJU_CHARM_TRACE_CONFIG_(H|G)"
JUJU_CHARM_TRACE_CONFIG_HTTP=http://tempo.lite.svc.cluster.local:4318
JUJU_CHARM_TRACE_CONFIG_GRPC=tempo.lite.svc.cluster.local:4317
```

:tada: 

### Setup Self Signing Certificate

This won't function from a real world experiment, but it is enough to show that it correctly integrates.

```sh
$ juju deploy self-signed-certificates --config ca-common-name="Example CA" ssc
$ juju integrate controller ssc
$ juju ssh -m controller 0
$ juju_db_repl
repl (controller)> SELECT * FROM charm_tracing_config
key             value
http-endpoint   http://tempo.lite.svc.cluster.local:4318
grpc-endpoint   tempo.lite.svc.cluster.local:4317
ca-certificate  -----BEGIN CERTIFICATE-----
MIIDWDCCAkCgAwIBAgIUHz/lL0Hg0b605bOWg+QFdbL8LMswDQYJKoZIhvcNAQEL
BQAwRDETMBEGA1UEAwwKRXhhbXBsZSBDQTEtMCsGA1UELQwkZmNhZTBiOTUtNzY3
NS00NzU0LThmNjktZDhkZGEyM2RkNWMyMB4XDTI2MDQxNjExMjY1MFoXDTI3MDQx
NjExMjY1MFowRDETMBEGA1UEAwwKRXhhbXBsZSBDQTEtMCsGA1UELQwkZmNhZTBi
OTUtNzY3NS00NzU0LThmNjktZDhkZGEyM2RkNWMyMIIBIjANBgkqhkiG9w0BAQEF
AAOCAQ8AMIIBCgKCAQEAsa6U+jk+bdHORLb9sICs8DNzjL5exhqv3agG8A2KHAWC
uXncCuS7xVMGsj3wSZb6zM7rg1toCmCYuI8qOqF8koYMnX2aMqE/8sjOQKvN+Tsq
ndUjjfKdrm3MB8/oq04IuLKKPb6qWwCtWOvqFQsgnfL9y2C3jV0idjbWTCFyt/Gt
VZbVVKZqGvWHq01T5mLOBpfwBON8F+5QytppdhLOboD9Q30rYmKmb1Hq3/I1XWVH
UTvC6nIUVe3+YPeOdirxOqyZkn6pWvoyw5baauqUjKetc1Oj88iC8ziVDhlOgcjA
mqXYRUtJ68B3QUklHvt+oaAxyK11aD/Fy+Av4W5/zwIDAQABo0IwQDAdBgNVHQ4E
FgQUDYPKkuSSRvTKrruHvjzuNKpfypUwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8B
Af8EBAMCAqQwDQYJKoZIhvcNAQELBQADggEBAIJdwuNl61ZdD0MAmJNqsHiIvKFq
O1hwg6DQtITf2FSMU6iMcxmc00Cl4NX1MRF5N7wCGNwYFKouxffxXf1u6HH6pC/E
lJrTyZ1wXTdZr7bpff5WfUL1rWwel4b5+WXJuLBkdJVJ9ECOd/4YsnsN2lapfH0g
t+tcMKN/MYKy8q9EEUaUl6e0yz13czcwpYV60e+Idhqp0VOpD81ks5cw7yAxDan8
PAo0KrJ5qblcKZhGdnZ7xukA2yThWW2ZD9OH/GcF2jx/999uRnsFt80HZTuY8UWm
IU/6D0h8lCcZTP+K3NtBbq0PoyQ6ZRMkMntqH20HPupGcWzHhkGMiFrWdlA=
-----END CERTIFICATE-----
```

You might have to trigger a hook invocation with something like `juju config -m controller controller identity-provider-url="bar"`.

```sh
root@juju-2bd818-0:/var/lib/juju/agents/unit-controller-0/charm# printenv | grep "JUJU_CHARM_TRACE_CONFIG_"
JUJU_CHARM_TRACE_CONFIG_HTTP=http://tempo.lite.svc.cluster.local:4318
JUJU_CHARM_TRACE_CONFIG_GRPC=tempo.lite.svc.cluster.local:4317
JUJU_CHARM_TRACE_CONFIG_CA_CERT=-----BEGIN CERTIFICATE-----
MIIDWDCCAkCgAwIBAgIUHz/lL0Hg0b605bOWg+QFdbL8LMswDQYJKoZIhvcNAQEL
BQAwRDETMBEGA1UEAwwKRXhhbXBsZSBDQTEtMCsGA1UELQwkZmNhZTBiOTUtNzY3
NS00NzU0LThmNjktZDhkZGEyM2RkNWMyMB4XDTI2MDQxNjExMjY1MFoXDTI3MDQx
NjExMjY1MFowRDETMBEGA1UEAwwKRXhhbXBsZSBDQTEtMCsGA1UELQwkZmNhZTBi
OTUtNzY3NS00NzU0LThmNjktZDhkZGEyM2RkNWMyMIIBIjANBgkqhkiG9w0BAQEF
AAOCAQ8AMIIBCgKCAQEAsa6U+jk+bdHORLb9sICs8DNzjL5exhqv3agG8A2KHAWC
uXncCuS7xVMGsj3wSZb6zM7rg1toCmCYuI8qOqF8koYMnX2aMqE/8sjOQKvN+Tsq
ndUjjfKdrm3MB8/oq04IuLKKPb6qWwCtWOvqFQsgnfL9y2C3jV0idjbWTCFyt/Gt
VZbVVKZqGvWHq01T5mLOBpfwBON8F+5QytppdhLOboD9Q30rYmKmb1Hq3/I1XWVH
UTvC6nIUVe3+YPeOdirxOqyZkn6pWvoyw5baauqUjKetc1Oj88iC8ziVDhlOgcjA
mqXYRUtJ68B3QUklHvt+oaAxyK11aD/Fy+Av4W5/zwIDAQABo0IwQDAdBgNVHQ4E
FgQUDYPKkuSSRvTKrruHvjzuNKpfypUwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8B
Af8EBAMCAqQwDQYJKoZIhvcNAQELBQADggEBAIJdwuNl61ZdD0MAmJNqsHiIvKFq
O1hwg6DQtITf2FSMU6iMcxmc00Cl4NX1MRF5N7wCGNwYFKouxffxXf1u6HH6pC/E
lJrTyZ1wXTdZr7bpff5WfUL1rWwel4b5+WXJuLBkdJVJ9ECOd/4YsnsN2lapfH0g
t+tcMKN/MYKy8q9EEUaUl6e0yz13czcwpYV60e+Idhqp0VOpD81ks5cw7yAxDan8
PAo0KrJ5qblcKZhGdnZ7xukA2yThWW2ZD9OH/GcF2jx/999uRnsFt80HZTuY8UWm
IU/6D0h8lCcZTP+K3NtBbq0PoyQ6ZRMkMntqH20HPupGcWzHhkGMiFrWdlA=
-----END CERTIFICATE-----
```

#### Remove the relation

This should remove the CA cert.

```sh
$ juju remove-relation -m controller controller ssc
$ juju ssh -m controller 0
$ juju_db_repl
repl (controller)> SELECT * FROM charm_tracing_config
key             value
http-endpoint   http://tempo.lite.svc.cluster.local:4318
grpc-endpoint   tempo.lite.svc.cluster.local:4317
```

Charm driven behavioural changes :tada: 

## Links

Jira Links: [JUJU-9450](https://warthogs.atlassian.net/browse/JUJU-9450) 

[JUJU-9450]: https://warthogs.atlassian.net/browse/JUJU-9450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ