### PR TITLE
fix: publish opened ports

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -13,9 +13,9 @@ import yaml
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from ops.charm import CharmBase, CollectStatusEvent
 from ops.framework import StoredState
-from ops.charm import InstallEvent, RelationJoinedEvent, RelationDepartedEvent
+from ops.charm import InstallEvent, RelationJoinedEvent, RelationDepartedEvent, UpgradeCharmEvent, UpdateStatusEvent
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, Relation
+from ops.model import ActiveStatus, BlockedStatus, ModelError, Relation
 from pathlib import Path
 from typing import List
 
@@ -28,6 +28,7 @@ class JujuControllerCharm(CharmBase):
     DB_BIND_ADDR_KEY = 'db-bind-address'
     ALL_BIND_ADDRS_KEY = 'db-bind-addresses'
     AGENT_ID_KEY = 'agent-id'
+    SSH_PORT = 17022
 
     _stored = StoredState()
 
@@ -38,6 +39,7 @@ class JujuControllerCharm(CharmBase):
 
         self._stored.set_default(
             last_bind_addresses=[],
+            ports_opened=False,
         )
 
         # TODO (manadart 2024-03-05): Get these at need.
@@ -50,6 +52,9 @@ class JujuControllerCharm(CharmBase):
     def _observe(self):
         """Set up all framework event observers."""
         self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.on.start, self._on_start)
+        self.framework.observe(self.on.update_status, self._on_update_status)
+        self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(
@@ -71,8 +76,33 @@ class JujuControllerCharm(CharmBase):
         Path(file_path).parent.mkdir(parents=True, exist_ok=True)
         open(file_path, 'w+').close()
 
+    def _on_upgrade_charm(self, event: UpgradeCharmEvent):
+        """Ensure ports are re-opened after a charm upgrade."""
+        self._stored.ports_opened = False
+
+    def _open_controller_ports(self) -> bool:
+        """Open controller ports and report success."""
+        try:
+            self.unit.open_port("tcp", self.api_port())
+        except (AgentConfException, ModelError) as e:
+            logger.error('cannot open controller API port: %s', e)
+            return False
+        try:
+            self.unit.open_port("tcp", self.SSH_PORT)
+        except ModelError as e:
+            logger.error('cannot open controller SSH proxy port: %s', e)
+            return False
+
+        return True
+
     def _on_start(self, _):
         self.unit.status = ActiveStatus()
+
+    def _on_update_status(self, _: UpdateStatusEvent):
+        if self._stored.ports_opened:
+            return
+        if self._open_controller_ports():
+            self._stored.ports_opened = True
 
     def _on_collect_status(self, event: CollectStatusEvent):
         if len(self._stored.last_bind_addresses) > 1:

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -63,6 +63,43 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(data["is-juju"], 'True')
         self.assertEqual(data.get("identity-provider-url"), None)
 
+    @patch("configchangesocket.ConfigChangeSocketClient.get_controller_agent_id",
+           return_value='0')
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("pathlib.Path.mkdir")
+    def test_install_does_not_open_ports(self, *_):
+        harness = self.harness
+        harness.charm.on.install.emit()
+        opened = [(p.protocol, p.port) for p in harness.model.unit.opened_ports()]
+        self.assertEqual(opened, [])
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    def test_start_does_not_open_ports(self, *_):
+        harness = self.harness
+        harness.charm.on.start.emit()
+        opened = [(p.protocol, p.port) for p in harness.model.unit.opened_ports()]
+        self.assertEqual(opened, [])
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    def test_update_status_opens_api_port(self, *_):
+        harness = self.harness
+        harness.charm.on.update_status.emit()
+        opened = [(p.protocol, p.port) for p in harness.model.unit.opened_ports()]
+        self.assertIn(('tcp', 17070), opened)
+        self.assertIn(('tcp', 17022), opened)
+
+    @patch("configchangesocket.ConfigChangeSocketClient.get_controller_agent_id",
+           return_value='0')
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    def test_upgrade_charm_reopens_ports_on_update_status(self, *_):
+        harness = self.harness
+        harness.charm.on.update_status.emit()
+        harness.charm.on.upgrade_charm.emit()
+        harness.charm.on.update_status.emit()
+        opened = [(p.protocol, p.port) for p in harness.model.unit.opened_ports()]
+        self.assertIn(('tcp', 17070), opened)
+        self.assertIn(('tcp', 17022), opened)
+
     @patch.dict(os.environ, {
         "JUJU_MACHINE_ID": "machine-0",
         "JUJU_UNIT_NAME": "controller/0"


### PR DESCRIPTION
Port publication was added to make controller ports visible in Juju
status, but doing it during install can race bootstrap initialization.
Therefore publication is done in a safer lifecycle point and tolerate
transient model/API conditions so controller startup remains reliable
while still exposing required ports.


## QA steps

Bootstrap with the modified charm:

```sh
charm pack --use-lxd

❯ juju bootstrap lxd src1 \
  --controller-charm-path $HOME/go/src/github.com/iyiguncevik/juju-controller/juju-controller_ubuntu@24.04-amd64.charm

❯ juju status -m src1:controller
Model       Controller  Cloud/Region         Version  Timestamp
controller  src1        localhost/localhost  4.0.4.1  12:30:05+01:00

App         Version  Status  Scale  Charm            Channel  Rev  Exposed  Message
controller           active      1  juju-controller             0  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.179.172.243  17022,17070/tcp

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.179.172.243  juju-2911e0-0  ubuntu@24.04  tuxedo  Running

❯ juju show-unit -m src1:controller controller/0 | yq '."controller/0"."opened-ports"'
- 17022/tcp
- 17070/tcp
```

Same but with a customer api port:

```sh
❯ juju bootstrap lxd src2 \
  --config api-port=27443 \
  --controller-charm-path $HOME/go/src/github.com/iyiguncevik/juju-controller/juju-controller_ubuntu@24.04-amd64.charm

❯ juju status -m src2:controller
Model       Controller  Cloud/Region         Version  Timestamp
controller  src2        localhost/localhost  4.0.4.1  12:41:19+01:00

App         Version  Status  Scale  Charm            Channel  Rev  Exposed  Message
controller           active      1  juju-controller             0  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.179.172.128  17022,27443/tcp

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.179.172.128  juju-384705-0  ubuntu@24.04  tuxedo  Running

❯ juju show-unit -m src2:controller controller/0 | yq '."controller/0"."opened-ports"'
- 17022/tcp
- 27443/tcp
```
## Links
- https://github.com/juju/juju/issues/21818