### PR TITLE
refactor: relation naming

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -18,11 +18,11 @@ provides:
     interface: prometheus_scrape
 
 requires:
-  tracing:
+  charm-tracing:
     interface: tracing
     limit: 1
     optional: true
-  receive-ca-cert:
+  charm-tracing-ca-cert:
     interface: certificate_transfer
     limit: 1
     optional: true

--- a/src/charm.py
+++ b/src/charm.py
@@ -39,10 +39,12 @@ class JujuControllerCharm(CharmBase):
         super().__init__(*args)
 
         self.tracing_requirer = TracingEndpointRequirer(
-            self, protocols=["otlp_http", "otlp_grpc"]
+            self,
+            protocols=["otlp_http", "otlp_grpc"],
+            relation_name='charm-tracing'
         )
         self._certificate_transfer = CertificateTransferRequires(
-            self, relationship_name='receive-ca-cert'
+            self, relationship_name='charm-tracing-ca-cert'
         )
 
         self._stored.set_default(

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -150,7 +150,7 @@ class TestCharm(unittest.TestCase):
     def test_tracing_relation_updates_endpoints(self, mock_set_tracing_config, *_):
         harness = self.harness
 
-        relation_id = harness.add_relation("tracing", "tempo-coordinator")
+        relation_id = harness.add_relation("charm-tracing", "tempo-coordinator")
         harness.add_relation_unit(relation_id, "tempo-coordinator/0")
 
         provider_data = tracing_provider_data()
@@ -189,7 +189,7 @@ class TestCharm(unittest.TestCase):
     def test_tracing_relation_update_propagates_socket_error(self, *_):
         harness = self.harness
 
-        relation_id = harness.add_relation("tracing", "tempo-coordinator")
+        relation_id = harness.add_relation("charm-tracing", "tempo-coordinator")
         harness.add_relation_unit(relation_id, "tempo-coordinator/0")
 
         with self.assertRaisesRegex(
@@ -204,7 +204,7 @@ class TestCharm(unittest.TestCase):
     def test_tracing_relation_removed_clears_endpoints(self, mock_set_tracing_config, *_):
         harness = self.harness
 
-        relation_id = harness.add_relation("tracing", "tempo-coordinator")
+        relation_id = harness.add_relation("charm-tracing", "tempo-coordinator")
         harness.add_relation_unit(relation_id, "tempo-coordinator/0")
 
         harness.update_relation_data(
@@ -235,7 +235,7 @@ class TestCharm(unittest.TestCase):
     def test_receive_ca_cert_updates_stored_ca_cert(self, mock_set_tracing_config, *_):
         harness = self.harness
 
-        relation_id = harness.add_relation("receive-ca-cert", "cert-provider")
+        relation_id = harness.add_relation("charm-tracing-ca-cert", "cert-provider")
         harness.add_relation_unit(relation_id, "cert-provider/0")
 
         cert_a = "-----BEGIN CERTIFICATE-----\na\n-----END CERTIFICATE-----"
@@ -271,7 +271,7 @@ class TestCharm(unittest.TestCase):
     def test_receive_ca_cert_removed_clears_stored_ca_cert(self, mock_set_tracing_config, *_):
         harness = self.harness
 
-        relation_id = harness.add_relation("receive-ca-cert", "cert-provider")
+        relation_id = harness.add_relation("charm-tracing-ca-cert", "cert-provider")
         harness.add_relation_unit(relation_id, "cert-provider/0")
 
         cert = "-----BEGIN CERTIFICATE-----\na\n-----END CERTIFICATE-----"


### PR DESCRIPTION
The relation names weren't ideal in the grand scheme of usage in the controller snap. Instead, if we naming the correctly it should allow us to add better versioning in the future.

----


### Setup Tempo

Build the charm with `charmcraft pack`

To make this proper, we need a COS-lite or something similar. I used [COS-lite on microk8s](https://documentation.ubuntu.com/observability/track-2/tutorial/installation/cos-lite-microk8s-sandbox/) and then deployed [tempo](https://documentation.ubuntu.com/observability/track-2/how-to/add-tracing-to-cos-lite/) in the same model.

Once there is a COS-lite with tempo we need to offer the `tempo:tracing` relation.

```sh
$ juju offer tempo:tracing
```

### Controller charm setup

To make this "simple" we can only deploy a local controller charm using IAAS controllers. So we need to bootstrap a IAAS controller (again for simplicity I'm using LXD).

```sh
$ juju bootstrap lxd test --bootstrap-base=ubuntu@24.04 --controller-charm-path=./juju-controller_ubuntu@24.04-amd64.charm
$ juju switch controller
$ juju consume cos:admin/lite.tempo
$ juju integrate controller:charm-tracing tempo:tracing
```

### Verify the endpoints are consumed

```sh
$ juju ssh -m test:controller controller 0
$ juju_db_repl
repl (controller)> SELECT * FROM charm_tracing_config
key             value
http-endpoint   http://tempo.m.svc.cluster.local:4318
grpc-endpoint   tempo.m.svc.cluster.local:4317
```

### Verify that the information is set as vars:

```sh
$ juju debug-hook -m controller controller/0
```

You might have to trigger a hook invocation with something like `juju config -m controller controller identity-provider-url="foo"`.

```sh
root@juju-2bd818-0:/var/lib/juju/agents/unit-controller-0/charm# printenv | grep -E "JUJU_CHARM_TRACE_CONFIG_(H|G)"
JUJU_CHARM_TRACE_CONFIG_HTTP=http://tempo.lite.svc.cluster.local:4318
JUJU_CHARM_TRACE_CONFIG_GRPC=tempo.lite.svc.cluster.local:4317
```

:tada: 
