### PR TITLE
fix: add correct "ca" key used by OpenTelemetry collector

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -84,6 +84,8 @@ class JujuControllerCharm(ops.CharmBase):
                 f"can't read controller API port from agent.conf: {e}")
             return
 
+        ca = self.ca_cert()
+
         metrics_endpoint = MetricsEndpointProvider(
             self,
             jobs=[{
@@ -99,7 +101,11 @@ class JujuControllerCharm(ops.CharmBase):
                     "password": password,
                 },
                 "tls_config": {
-                    "ca_file": self.ca_cert(),
+                    "ca": ca,
+                    # Note that this key, although incorrect, is retained for
+                    # backward compatibility. The operator for OpenTelemetry
+                    # uses the "ca" key, above.
+                    "ca_file": ca,
                     "server_name": "juju-apiserver",
                 },
             }],

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -102,6 +102,7 @@ class TestCharm(unittest.TestCase):
                     "password": 'passwd',
                 },
                 "tls_config": {
+                    "ca": 'fake',
                     "ca_file": 'fake',
                     "server_name": "juju-apiserver",
                 },


### PR DESCRIPTION
The old key was replaced in a prior patch, https://github.com/juju/juju-controller/pull/101. 

This was subsequently reverted by https://github.com/juju/juju-controller/pull/105, due to breaking compatibility with existing related charms such as `prometheus-k8s`.

Here, we simply duplicate the value under a new key name so that compatibility with all concerned charms is upheld.