### PR TITLE
feat: workload tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 venv
 /.idea/
 /.vscode/
+.envrc

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -26,6 +26,14 @@ requires:
     interface: certificate_transfer
     limit: 1
     optional: true
+  workload-tracing:
+    interface: tracing
+    limit: 1
+    optional: true
+  workload-tracing-ca-cert:
+    interface: certificate_transfer
+    limit: 1
+    optional: true
   s3-backend:
     interface: s3
     limit: 1

--- a/config.yaml
+++ b/config.yaml
@@ -14,3 +14,15 @@ options:
     default: true
     description: Whether this is a standalone Juju controller
     type: boolean
+  open-telemetry-stack-traces:
+    default: false
+    description: Whether stack traces should be added per OpenTelemetry span.
+    type: boolean
+  open-telemetry-sample-ratio:
+    default: 0.1
+    description: The OpenTelemetry sampling ratio (must be between 0 and 1).
+    type: float
+  open-telemetry-tail-sampling-threshold:
+    default: "1ms"
+    description: The OpenTelemetry tail sampling threshold as a duration string.
+    type: string

--- a/config.yaml
+++ b/config.yaml
@@ -26,3 +26,7 @@ options:
     default: "1ms"
     description: The OpenTelemetry tail sampling threshold as a duration string.
     type: string
+  workload-tracing-insecure-skip-verify:
+    default: false
+    description: Whether workload tracing should skip TLS certificate verification.
+    type: boolean

--- a/src/charm.py
+++ b/src/charm.py
@@ -323,11 +323,11 @@ class JujuControllerCharm(CharmBase):
             ),
         }
         logger.info("workload tracing endpoints updated: %s", endpoints)
-        self._update_workload_tracing_config()
+        self._update_workload_tracing_config(allow_endpoint_only=True)
 
     def _on_workload_tracing_relation_removed(self, event):
         logger.info("workload tracing endpoints cleared")
-        self._update_workload_tracing_config()
+        self._update_workload_tracing_config(allow_endpoint_only=True)
 
     def _on_receive_workload_ca_cert_updated(self, event):
         ca_list = event.certificates
@@ -335,11 +335,11 @@ class JujuControllerCharm(CharmBase):
             return
 
         logger.info("workload CA certificate updated from relation id %s", event.relation_id)
-        self._update_workload_tracing_config()
+        self._update_workload_tracing_config(allow_endpoint_only=True)
 
     def _on_receive_workload_ca_cert_removed(self, event):
         logger.info("workload CA certificate removed from relation id %s", event.relation_id)
-        self._update_workload_tracing_config()
+        self._update_workload_tracing_config(allow_endpoint_only=True)
 
     def _update_bind_addresses(self, relation):
         """Maintain our own bind address in relation data.
@@ -522,12 +522,13 @@ class JujuControllerCharm(CharmBase):
             logger.error("failed to set charm tracing config: %s", exc)
             self._stored.tracing_status_error = "failed to set charm tracing config"
 
-    def _update_workload_tracing_config(self):
+    def _update_workload_tracing_config(self, allow_endpoint_only=False):
         """Update workload tracing configuration with current endpoint and CA cert information."""
         if not self.unit.is_leader():
             return
 
         grpc_endpoint, http_endpoint, ca_cert = self._current_workload_tracing_config()
+        open_telemetry_config = {}
         try:
             (
                 open_telemetry_stack_traces,
@@ -535,22 +536,27 @@ class JujuControllerCharm(CharmBase):
                 open_telemetry_tail_sampling_threshold,
                 insecure_skip_verify,
             ) = self._current_open_telemetry_config()
+            open_telemetry_config = {
+                "open_telemetry_stack_traces": open_telemetry_stack_traces,
+                "open_telemetry_sample_ratio": open_telemetry_sample_ratio,
+                "open_telemetry_tail_sampling_threshold": open_telemetry_tail_sampling_threshold,
+                "insecure_skip_verify": insecure_skip_verify,
+            }
         except ValueError as exc:
             logger.error("%s", exc)
             self._stored.workload_tracing_status_error = str(exc)
-            return
+            if not allow_endpoint_only:
+                return
 
         try:
             self._control_socket.set_workload_tracing_config(
                 grpc_endpoint=grpc_endpoint,
                 http_endpoint=http_endpoint,
                 ca_cert=ca_cert,
-                open_telemetry_stack_traces=open_telemetry_stack_traces,
-                open_telemetry_sample_ratio=open_telemetry_sample_ratio,
-                open_telemetry_tail_sampling_threshold=open_telemetry_tail_sampling_threshold,
-                insecure_skip_verify=insecure_skip_verify,
+                **open_telemetry_config,
             )
-            self._stored.workload_tracing_status_error = None
+            if open_telemetry_config:
+                self._stored.workload_tracing_status_error = None
         except Exception as exc:
             logger.error("failed to set workload tracing config: %s", exc)
             self._stored.workload_tracing_status_error = "failed to set workload tracing config"

--- a/src/charm.py
+++ b/src/charm.py
@@ -202,6 +202,7 @@ class JujuControllerCharm(CharmBase):
     def _on_config_changed(self, _):
         controller_url = self.config['controller-url']
         logger.info('got a new controller-url: %r', controller_url)
+        self._update_charm_tracing_config()
 
     def _on_dashboard_relation_joined(self, event):
         logger.info('got a new dashboard relation: %r', event)
@@ -488,6 +489,21 @@ class JujuControllerCharm(CharmBase):
             certificate_transfer=self.workload_certificate_transfer,
         )
 
+    def _validate_open_telemetry_sample_ratio(self, sample_ratio: float):
+        if sample_ratio < 0 or sample_ratio > 1:
+            raise ValueError(
+                "invalid open-telemetry-sample-ratio: must be between 0 and 1"
+            )
+
+    def _current_open_telemetry_config(self) -> Tuple[bool, float, str]:
+        sample_ratio = float(self.config["open-telemetry-sample-ratio"])
+        self._validate_open_telemetry_sample_ratio(sample_ratio)
+        return (
+            self.config["open-telemetry-stack-traces"],
+            sample_ratio,
+            self.config["open-telemetry-tail-sampling-threshold"],
+        )
+
     def _update_charm_tracing_config(self):
         """Update charm configuration with current tracing endpoint and CA cert information."""
         if not self.unit.is_leader():
@@ -495,10 +511,24 @@ class JujuControllerCharm(CharmBase):
 
         grpc_endpoint, http_endpoint, ca_cert = self._current_charm_tracing_config()
         try:
+            (
+                open_telemetry_stack_traces,
+                open_telemetry_sample_ratio,
+                open_telemetry_tail_sampling_threshold,
+            ) = self._current_open_telemetry_config()
+        except ValueError as exc:
+            logger.error("%s", exc)
+            self._stored.tracing_status_error = str(exc)
+            return
+
+        try:
             self._control_socket.set_charm_tracing_config(
                 grpc_endpoint=grpc_endpoint,
                 http_endpoint=http_endpoint,
                 ca_cert=ca_cert,
+                open_telemetry_stack_traces=open_telemetry_stack_traces,
+                open_telemetry_sample_ratio=open_telemetry_sample_ratio,
+                open_telemetry_tail_sampling_threshold=open_telemetry_tail_sampling_threshold,
             )
             self._stored.tracing_status_error = None
         except Exception as exc:

--- a/src/charm.py
+++ b/src/charm.py
@@ -202,7 +202,7 @@ class JujuControllerCharm(CharmBase):
     def _on_config_changed(self, _):
         controller_url = self.config['controller-url']
         logger.info('got a new controller-url: %r', controller_url)
-        self._update_charm_tracing_config()
+        self._update_workload_tracing_config()
 
     def _on_dashboard_relation_joined(self, event):
         logger.info('got a new dashboard relation: %r', event)
@@ -495,13 +495,14 @@ class JujuControllerCharm(CharmBase):
                 "invalid open-telemetry-sample-ratio: must be between 0 and 1"
             )
 
-    def _current_open_telemetry_config(self) -> Tuple[bool, float, str]:
+    def _current_open_telemetry_config(self) -> Tuple[bool, float, str, bool]:
         sample_ratio = float(self.config["open-telemetry-sample-ratio"])
         self._validate_open_telemetry_sample_ratio(sample_ratio)
         return (
             self.config["open-telemetry-stack-traces"],
             sample_ratio,
             self.config["open-telemetry-tail-sampling-threshold"],
+            self.config["workload-tracing-insecure-skip-verify"],
         )
 
     def _update_charm_tracing_config(self):
@@ -511,24 +512,10 @@ class JujuControllerCharm(CharmBase):
 
         grpc_endpoint, http_endpoint, ca_cert = self._current_charm_tracing_config()
         try:
-            (
-                open_telemetry_stack_traces,
-                open_telemetry_sample_ratio,
-                open_telemetry_tail_sampling_threshold,
-            ) = self._current_open_telemetry_config()
-        except ValueError as exc:
-            logger.error("%s", exc)
-            self._stored.tracing_status_error = str(exc)
-            return
-
-        try:
             self._control_socket.set_charm_tracing_config(
                 grpc_endpoint=grpc_endpoint,
                 http_endpoint=http_endpoint,
                 ca_cert=ca_cert,
-                open_telemetry_stack_traces=open_telemetry_stack_traces,
-                open_telemetry_sample_ratio=open_telemetry_sample_ratio,
-                open_telemetry_tail_sampling_threshold=open_telemetry_tail_sampling_threshold,
             )
             self._stored.tracing_status_error = None
         except Exception as exc:
@@ -542,10 +529,26 @@ class JujuControllerCharm(CharmBase):
 
         grpc_endpoint, http_endpoint, ca_cert = self._current_workload_tracing_config()
         try:
+            (
+                open_telemetry_stack_traces,
+                open_telemetry_sample_ratio,
+                open_telemetry_tail_sampling_threshold,
+                insecure_skip_verify,
+            ) = self._current_open_telemetry_config()
+        except ValueError as exc:
+            logger.error("%s", exc)
+            self._stored.workload_tracing_status_error = str(exc)
+            return
+
+        try:
             self._control_socket.set_workload_tracing_config(
                 grpc_endpoint=grpc_endpoint,
                 http_endpoint=http_endpoint,
                 ca_cert=ca_cert,
+                open_telemetry_stack_traces=open_telemetry_stack_traces,
+                open_telemetry_sample_ratio=open_telemetry_sample_ratio,
+                open_telemetry_tail_sampling_threshold=open_telemetry_tail_sampling_threshold,
+                insecure_skip_verify=insecure_skip_verify,
             )
             self._stored.workload_tracing_status_error = None
         except Exception as exc:

--- a/src/charm.py
+++ b/src/charm.py
@@ -39,18 +39,27 @@ class JujuControllerCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
-        self.tracing_requirer = TracingEndpointRequirer(
+        self.charm_tracing_requirer = TracingEndpointRequirer(
             self,
             protocols=["otlp_http", "otlp_grpc"],
             relation_name='charm-tracing'
         )
-        self._certificate_transfer = CertificateTransferRequires(
+        self.charm_certificate_transfer = CertificateTransferRequires(
             self, relationship_name='charm-tracing-ca-cert'
+        )
+        self.workload_tracing_requirer = TracingEndpointRequirer(
+            self,
+            protocols=["otlp_http", "otlp_grpc"],
+            relation_name='workload-tracing'
+        )
+        self.workload_certificate_transfer = CertificateTransferRequires(
+            self, relationship_name='workload-tracing-ca-cert'
         )
 
         self._stored.set_default(
             last_bind_addresses=[],
             tracing_status_error=None,
+            workload_tracing_status_error=None,
             s3_status_error=None,
             s3_status_pending=False,
         )
@@ -85,15 +94,33 @@ class JujuControllerCharm(CharmBase):
         self.framework.observe(
             self.on.dbcluster_relation_departed, self._on_dbcluster_relation_departed)
         self.framework.observe(
-            self.tracing_requirer.on.endpoint_changed, self._on_tracing_relation_changed)
+            self.charm_tracing_requirer.on.endpoint_changed, self._on_tracing_relation_changed)
         self.framework.observe(
-            self.tracing_requirer.on.endpoint_removed, self._on_tracing_relation_removed)
+            self.charm_tracing_requirer.on.endpoint_removed, self._on_tracing_relation_removed)
         self.framework.observe(
-            self._certificate_transfer.on.certificate_set_updated,
+            self.charm_certificate_transfer.on.certificate_set_updated,
             self._on_receive_ca_cert_updated,
         )
         self.framework.observe(
-            self._certificate_transfer.on.certificates_removed, self._on_receive_ca_cert_removed)
+            self.charm_certificate_transfer.on.certificates_removed,
+            self._on_receive_ca_cert_removed,
+        )
+        self.framework.observe(
+            self.workload_tracing_requirer.on.endpoint_changed,
+            self._on_workload_tracing_relation_changed,
+        )
+        self.framework.observe(
+            self.workload_tracing_requirer.on.endpoint_removed,
+            self._on_workload_tracing_relation_removed,
+        )
+        self.framework.observe(
+            self.workload_certificate_transfer.on.certificate_set_updated,
+            self._on_receive_workload_ca_cert_updated,
+        )
+        self.framework.observe(
+            self.workload_certificate_transfer.on.certificates_removed,
+            self._on_receive_workload_ca_cert_removed,
+        )
         self.framework.observe(
             self._s3.on.credentials_changed, self._on_s3_credentials_changed)
         self.framework.observe(
@@ -110,6 +137,7 @@ class JujuControllerCharm(CharmBase):
 
     def _on_leader_elected(self, _event: LeaderElectedEvent):
         self._update_charm_tracing_config()
+        self._update_workload_tracing_config()
 
         # Read current relation data rather than relying on locally cached
         # state. This avoids replaying stale credentials if this unit becomes
@@ -152,6 +180,10 @@ class JujuControllerCharm(CharmBase):
 
         if self._stored.tracing_status_error:
             event.add_status(BlockedStatus(self._stored.tracing_status_error))
+            has_blocking_status = True
+
+        if self._stored.workload_tracing_status_error:
+            event.add_status(BlockedStatus(self._stored.workload_tracing_status_error))
             has_blocking_status = True
 
         if self._stored.s3_status_error:
@@ -251,12 +283,12 @@ class JujuControllerCharm(CharmBase):
         self._update_bind_addresses(relation)
 
     def _on_tracing_relation_changed(self, event):
-        if not self.tracing_requirer.is_ready(event.relation):
+        if not self.charm_tracing_requirer.is_ready(event.relation):
             return
 
         endpoints = {
-            "otlp_grpc": self.tracing_requirer.get_endpoint("otlp_grpc", event.relation),
-            "otlp_http": self.tracing_requirer.get_endpoint("otlp_http", event.relation),
+            "otlp_grpc": self.charm_tracing_requirer.get_endpoint("otlp_grpc", event.relation),
+            "otlp_http": self.charm_tracing_requirer.get_endpoint("otlp_http", event.relation),
         }
         logger.info("tracing endpoints updated: %s", endpoints)
         self._update_charm_tracing_config()
@@ -276,6 +308,37 @@ class JujuControllerCharm(CharmBase):
     def _on_receive_ca_cert_removed(self, event):
         logger.info("CA certificate removed from relation id %s", event.relation_id)
         self._update_charm_tracing_config()
+
+    def _on_workload_tracing_relation_changed(self, event):
+        if not self.workload_tracing_requirer.is_ready(event.relation):
+            return
+
+        endpoints = {
+            "otlp_grpc": self.workload_tracing_requirer.get_endpoint(
+                "otlp_grpc", event.relation
+            ),
+            "otlp_http": self.workload_tracing_requirer.get_endpoint(
+                "otlp_http", event.relation
+            ),
+        }
+        logger.info("workload tracing endpoints updated: %s", endpoints)
+        self._update_workload_tracing_config()
+
+    def _on_workload_tracing_relation_removed(self, event):
+        logger.info("workload tracing endpoints cleared")
+        self._update_workload_tracing_config()
+
+    def _on_receive_workload_ca_cert_updated(self, event):
+        ca_list = event.certificates
+        if not ca_list:
+            return
+
+        logger.info("workload CA certificate updated from relation id %s", event.relation_id)
+        self._update_workload_tracing_config()
+
+    def _on_receive_workload_ca_cert_removed(self, event):
+        logger.info("workload CA certificate removed from relation id %s", event.relation_id)
+        self._update_workload_tracing_config()
 
     def _update_bind_addresses(self, relation):
         """Maintain our own bind address in relation data.
@@ -393,11 +456,13 @@ class JujuControllerCharm(CharmBase):
 
     def _current_tracing_config(
         self,
+        tracing_requirer: TracingEndpointRequirer,
+        certificate_transfer: CertificateTransferRequires,
     ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
         grpc_endpoint: Optional[str] = None
         http_endpoint: Optional[str] = None
 
-        tracing_data = self.tracing_requirer.get_all_endpoints()
+        tracing_data = tracing_requirer.get_all_endpoints()
         if tracing_data:
             for receiver in tracing_data.receivers:
                 if receiver.protocol.name == "otlp_grpc" and grpc_endpoint is None:
@@ -405,16 +470,30 @@ class JujuControllerCharm(CharmBase):
                 if receiver.protocol.name == "otlp_http" and http_endpoint is None:
                     http_endpoint = receiver.url
 
-        certificates = self._certificate_transfer.get_all_certificates()
+        certificates = certificate_transfer.get_all_certificates()
         ca_cert = "\n".join(sorted(certificates)) if certificates else None
         return grpc_endpoint, http_endpoint, ca_cert
+
+    def _current_charm_tracing_config(self) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        return self._current_tracing_config(
+            tracing_requirer=self.charm_tracing_requirer,
+            certificate_transfer=self.charm_certificate_transfer,
+        )
+
+    def _current_workload_tracing_config(
+        self,
+    ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        return self._current_tracing_config(
+            tracing_requirer=self.workload_tracing_requirer,
+            certificate_transfer=self.workload_certificate_transfer,
+        )
 
     def _update_charm_tracing_config(self):
         """Update charm configuration with current tracing endpoint and CA cert information."""
         if not self.unit.is_leader():
             return
 
-        grpc_endpoint, http_endpoint, ca_cert = self._current_tracing_config()
+        grpc_endpoint, http_endpoint, ca_cert = self._current_charm_tracing_config()
         try:
             self._control_socket.set_charm_tracing_config(
                 grpc_endpoint=grpc_endpoint,
@@ -425,6 +504,23 @@ class JujuControllerCharm(CharmBase):
         except Exception as exc:
             logger.error("failed to set charm tracing config: %s", exc)
             self._stored.tracing_status_error = "failed to set charm tracing config"
+
+    def _update_workload_tracing_config(self):
+        """Update workload tracing configuration with current endpoint and CA cert information."""
+        if not self.unit.is_leader():
+            return
+
+        grpc_endpoint, http_endpoint, ca_cert = self._current_workload_tracing_config()
+        try:
+            self._control_socket.set_workload_tracing_config(
+                grpc_endpoint=grpc_endpoint,
+                http_endpoint=http_endpoint,
+                ca_cert=ca_cert,
+            )
+            self._stored.workload_tracing_status_error = None
+        except Exception as exc:
+            logger.error("failed to set workload tracing config: %s", exc)
+            self._stored.workload_tracing_status_error = "failed to set workload tracing config"
 
     def _on_s3_credentials_changed(self, event: CredentialsChangedEvent):
         """Handle new or updated S3 credentials."""

--- a/src/controlsocket.py
+++ b/src/controlsocket.py
@@ -52,6 +52,25 @@ class ControlSocketClient(unixsocket.SocketClient):
         )
         logger.debug('result of set_charm_tracing_config request: %r', resp)
 
+    def set_workload_tracing_config(
+        self,
+        grpc_endpoint: Optional[str],
+        http_endpoint: Optional[str],
+        ca_cert: Optional[str],
+    ):
+        """Set the tracing configuration for the controller workload."""
+        body = {
+            "grpc_endpoint": grpc_endpoint,
+            "http_endpoint": http_endpoint,
+            "ca_cert": ca_cert,
+        }
+        resp = self.json_request(
+            method='POST',
+            path='/workload-tracing-config',
+            body=body,
+        )
+        logger.debug('result of set_workload_tracing_config request: %r', resp)
+
     def add_s3_credentials(self, credentials: dict):
         resp = self.json_request(
             method='POST',

--- a/src/controlsocket.py
+++ b/src/controlsocket.py
@@ -38,6 +38,9 @@ class ControlSocketClient(unixsocket.SocketClient):
         grpc_endpoint: Optional[str],
         http_endpoint: Optional[str],
         ca_cert: Optional[str],
+        open_telemetry_stack_traces: Optional[bool] = None,
+        open_telemetry_sample_ratio: Optional[float] = None,
+        open_telemetry_tail_sampling_threshold: Optional[str] = None,
     ):
         """Set the tracing configuration for the charm."""
         body = {
@@ -45,6 +48,14 @@ class ControlSocketClient(unixsocket.SocketClient):
             "http_endpoint": http_endpoint,
             "ca_cert": ca_cert,
         }
+        if open_telemetry_stack_traces is not None:
+            body["open_telemetry_stack_traces"] = open_telemetry_stack_traces
+        if open_telemetry_sample_ratio is not None:
+            body["open_telemetry_sample_ratio"] = open_telemetry_sample_ratio
+        if open_telemetry_tail_sampling_threshold is not None:
+            body["open_telemetry_tail_sampling_threshold"] = (
+                open_telemetry_tail_sampling_threshold
+            )
         resp = self.json_request(
             method='POST',
             path='/charm-tracing-config',

--- a/src/controlsocket.py
+++ b/src/controlsocket.py
@@ -38,11 +38,31 @@ class ControlSocketClient(unixsocket.SocketClient):
         grpc_endpoint: Optional[str],
         http_endpoint: Optional[str],
         ca_cert: Optional[str],
+    ):
+        """Set the tracing configuration for the charm."""
+        body = {
+            "grpc_endpoint": grpc_endpoint,
+            "http_endpoint": http_endpoint,
+            "ca_cert": ca_cert,
+        }
+        resp = self.json_request(
+            method='POST',
+            path='/charm-tracing-config',
+            body=body,
+        )
+        logger.debug('result of set_charm_tracing_config request: %r', resp)
+
+    def set_workload_tracing_config(
+        self,
+        grpc_endpoint: Optional[str],
+        http_endpoint: Optional[str],
+        ca_cert: Optional[str],
         open_telemetry_stack_traces: Optional[bool] = None,
         open_telemetry_sample_ratio: Optional[float] = None,
         open_telemetry_tail_sampling_threshold: Optional[str] = None,
+        insecure_skip_verify: Optional[bool] = None,
     ):
-        """Set the tracing configuration for the charm."""
+        """Set the tracing configuration for the controller workload."""
         body = {
             "grpc_endpoint": grpc_endpoint,
             "http_endpoint": http_endpoint,
@@ -56,25 +76,8 @@ class ControlSocketClient(unixsocket.SocketClient):
             body["open_telemetry_tail_sampling_threshold"] = (
                 open_telemetry_tail_sampling_threshold
             )
-        resp = self.json_request(
-            method='POST',
-            path='/charm-tracing-config',
-            body=body,
-        )
-        logger.debug('result of set_charm_tracing_config request: %r', resp)
-
-    def set_workload_tracing_config(
-        self,
-        grpc_endpoint: Optional[str],
-        http_endpoint: Optional[str],
-        ca_cert: Optional[str],
-    ):
-        """Set the tracing configuration for the controller workload."""
-        body = {
-            "grpc_endpoint": grpc_endpoint,
-            "http_endpoint": http_endpoint,
-            "ca_cert": ca_cert,
-        }
+        if insecure_skip_verify is not None:
+            body["insecure_skip_verify"] = insecure_skip_verify
         resp = self.json_request(
             method='POST',
             path='/workload-tracing-config',

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -170,9 +170,6 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -188,9 +185,6 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -215,9 +209,6 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -305,9 +296,6 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
         )
 
         harness.remove_relation(relation_id)
@@ -317,9 +305,6 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -344,9 +329,6 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert="\n".join([cert_a, cert_b]),
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -381,9 +363,6 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=cert,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
         )
 
         harness.remove_relation(relation_id)
@@ -393,9 +372,6 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -417,18 +393,20 @@ class TestCharm(unittest.TestCase):
                 "open-telemetry-stack-traces": True,
                 "open-telemetry-sample-ratio": 0.5,
                 "open-telemetry-tail-sampling-threshold": "250ms",
+                "workload-tracing-insecure-skip-verify": True,
             }
         )
 
-        mock_set_charm_tracing_config.assert_called_once_with(
+        mock_set_charm_tracing_config.assert_not_called()
+        mock_set_workload_tracing_config.assert_called_once_with(
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
             open_telemetry_stack_traces=True,
             open_telemetry_sample_ratio=0.5,
             open_telemetry_tail_sampling_threshold="250ms",
+            insecure_skip_verify=True,
         )
-        mock_set_workload_tracing_config.assert_not_called()
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
     @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
@@ -481,24 +459,26 @@ class TestCharm(unittest.TestCase):
 
         harness.update_config({"open-telemetry-sample-ratio": 0.25})
 
-        mock_set_charm_tracing_config.assert_called_once_with(
+        mock_set_charm_tracing_config.assert_not_called()
+        mock_set_workload_tracing_config.assert_called_once_with(
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
             open_telemetry_stack_traces=False,
             open_telemetry_sample_ratio=0.25,
             open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
         )
         with patch.object(harness.charm, "api_port", return_value=17070):
             harness.evaluate_status()
         self.assertIsInstance(harness.charm.unit.status, ActiveStatus)
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
-    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
     @patch(
-        "controlsocket.ControlSocketClient.set_charm_tracing_config",
+        "controlsocket.ControlSocketClient.set_workload_tracing_config",
         side_effect=SocketConnectionError("could not connect to socket"),
     )
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
     def test_config_changed_sets_blocked_status_on_socket_error(
         self,
         _mock_set_charm_tracing_config,
@@ -512,13 +492,21 @@ class TestCharm(unittest.TestCase):
 
         harness.update_config({"open-telemetry-sample-ratio": 0.5})
 
-        mock_set_workload_tracing_config.assert_not_called()
+        mock_set_workload_tracing_config.assert_called_once_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.5,
+            open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
+        )
         with patch.object(harness.charm, "api_port", return_value=17070):
             harness.evaluate_status()
         self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
         self.assertEqual(
             harness.charm.unit.status.message,
-            "failed to set charm tracing config",
+            "failed to set workload tracing config",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -535,7 +523,7 @@ class TestCharm(unittest.TestCase):
         mock_set_charm_tracing_config.reset_mock()
         mock_set_workload_tracing_config.reset_mock()
 
-        mock_set_charm_tracing_config.side_effect = [
+        mock_set_workload_tracing_config.side_effect = [
             SocketConnectionError("could not connect to socket"),
             None,
         ]
@@ -545,14 +533,14 @@ class TestCharm(unittest.TestCase):
             harness.evaluate_status()
         self.assertEqual(
             harness.charm.unit.status.message,
-            "failed to set charm tracing config",
+            "failed to set workload tracing config",
         )
 
         harness.update_config({"open-telemetry-stack-traces": True})
         with patch.object(harness.charm, "api_port", return_value=17070):
             harness.evaluate_status()
         self.assertIsInstance(harness.charm.unit.status, ActiveStatus)
-        mock_set_workload_tracing_config.assert_not_called()
+        mock_set_charm_tracing_config.assert_not_called()
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
     @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
@@ -579,9 +567,6 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
         )
         mock_set_workload_tracing_config.assert_not_called()
 
@@ -591,9 +576,6 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
         )
         mock_set_workload_tracing_config.assert_not_called()
 
@@ -623,6 +605,10 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -642,6 +628,10 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -672,6 +662,10 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
         )
 
     @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
@@ -782,6 +776,10 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
         )
 
         harness.remove_relation(relation_id)
@@ -791,6 +789,10 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -818,6 +820,10 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
         )
         mock_set_charm_tracing_config.assert_not_called()
 
@@ -827,6 +833,10 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
         )
         mock_set_charm_tracing_config.assert_not_called()
 
@@ -858,6 +868,10 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert="\n".join([cert_a, cert_b]),
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
         )
 
     @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
@@ -897,6 +911,10 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=cert,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
         )
 
         harness.remove_relation(relation_id)
@@ -906,6 +924,10 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf_apiaddresses_missing)

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -170,6 +170,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -185,6 +188,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -209,6 +215,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -296,6 +305,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
         )
 
         harness.remove_relation(relation_id)
@@ -305,6 +317,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -329,6 +344,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert="\n".join([cert_a, cert_b]),
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -363,6 +381,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=cert,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
         )
 
         harness.remove_relation(relation_id)
@@ -372,7 +393,166 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
         )
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    def test_config_changed_updates_open_telemetry_tracing_values(
+        self,
+        mock_set_charm_tracing_config,
+        mock_set_workload_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_charm_tracing_config.reset_mock()
+        mock_set_workload_tracing_config.reset_mock()
+
+        harness.update_config(
+            {
+                "open-telemetry-stack-traces": True,
+                "open-telemetry-sample-ratio": 0.5,
+                "open-telemetry-tail-sampling-threshold": "250ms",
+            }
+        )
+
+        mock_set_charm_tracing_config.assert_called_once_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=None,
+            open_telemetry_stack_traces=True,
+            open_telemetry_sample_ratio=0.5,
+            open_telemetry_tail_sampling_threshold="250ms",
+        )
+        mock_set_workload_tracing_config.assert_not_called()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    def test_config_changed_invalid_open_telemetry_sample_ratio_sets_blocked(
+        self,
+        mock_set_charm_tracing_config,
+        mock_set_workload_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_charm_tracing_config.reset_mock()
+        mock_set_workload_tracing_config.reset_mock()
+
+        harness.update_config({"open-telemetry-sample-ratio": 1.1})
+
+        mock_set_charm_tracing_config.assert_not_called()
+        mock_set_workload_tracing_config.assert_not_called()
+        with patch.object(harness.charm, "api_port", return_value=17070):
+            harness.evaluate_status()
+        self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
+        self.assertEqual(
+            harness.charm.unit.status.message,
+            "invalid open-telemetry-sample-ratio: must be between 0 and 1",
+        )
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    def test_config_changed_invalid_open_telemetry_sample_ratio_recovers_on_valid_update(
+        self,
+        mock_set_charm_tracing_config,
+        mock_set_workload_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_charm_tracing_config.reset_mock()
+        mock_set_workload_tracing_config.reset_mock()
+
+        harness.update_config({"open-telemetry-sample-ratio": 1.1})
+        with patch.object(harness.charm, "api_port", return_value=17070):
+            harness.evaluate_status()
+        self.assertEqual(
+            harness.charm.unit.status.message,
+            "invalid open-telemetry-sample-ratio: must be between 0 and 1",
+        )
+        mock_set_charm_tracing_config.assert_not_called()
+
+        harness.update_config({"open-telemetry-sample-ratio": 0.25})
+
+        mock_set_charm_tracing_config.assert_called_once_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.25,
+            open_telemetry_tail_sampling_threshold="1ms",
+        )
+        with patch.object(harness.charm, "api_port", return_value=17070):
+            harness.evaluate_status()
+        self.assertIsInstance(harness.charm.unit.status, ActiveStatus)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    @patch(
+        "controlsocket.ControlSocketClient.set_charm_tracing_config",
+        side_effect=SocketConnectionError("could not connect to socket"),
+    )
+    def test_config_changed_sets_blocked_status_on_socket_error(
+        self,
+        _mock_set_charm_tracing_config,
+        mock_set_workload_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        _mock_set_charm_tracing_config.reset_mock()
+        mock_set_workload_tracing_config.reset_mock()
+
+        harness.update_config({"open-telemetry-sample-ratio": 0.5})
+
+        mock_set_workload_tracing_config.assert_not_called()
+        with patch.object(harness.charm, "api_port", return_value=17070):
+            harness.evaluate_status()
+        self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
+        self.assertEqual(
+            harness.charm.unit.status.message,
+            "failed to set charm tracing config",
+        )
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    def test_config_changed_socket_error_status_recovers_after_success(
+        self,
+        mock_set_charm_tracing_config,
+        mock_set_workload_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_charm_tracing_config.reset_mock()
+        mock_set_workload_tracing_config.reset_mock()
+
+        mock_set_charm_tracing_config.side_effect = [
+            SocketConnectionError("could not connect to socket"),
+            None,
+        ]
+        harness.update_config({"open-telemetry-sample-ratio": 0.5})
+
+        with patch.object(harness.charm, "api_port", return_value=17070):
+            harness.evaluate_status()
+        self.assertEqual(
+            harness.charm.unit.status.message,
+            "failed to set charm tracing config",
+        )
+
+        harness.update_config({"open-telemetry-stack-traces": True})
+        with patch.object(harness.charm, "api_port", return_value=17070):
+            harness.evaluate_status()
+        self.assertIsInstance(harness.charm.unit.status, ActiveStatus)
+        mock_set_workload_tracing_config.assert_not_called()
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
     @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
@@ -399,6 +579,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
         )
         mock_set_workload_tracing_config.assert_not_called()
 
@@ -408,6 +591,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
         )
         mock_set_workload_tracing_config.assert_not_called()
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -798,6 +798,56 @@ class TestCharm(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
     @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
     @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_workload_tracing_relation_removed_clears_endpoints_with_invalid_config(
+        self,
+        mock_set_workload_tracing_config,
+        _mock_set_charm_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_workload_tracing_config.reset_mock()
+
+        relation_id = harness.add_relation("workload-tracing", "tempo-coordinator")
+        harness.add_relation_unit(relation_id, "tempo-coordinator/0")
+
+        harness.update_relation_data(
+            relation_id,
+            "tempo-coordinator",
+            tracing_provider_data(),
+        )
+        mock_set_workload_tracing_config.assert_called_once_with(
+            grpc_endpoint="tempo-grpc:4317",
+            http_endpoint="http://tempo-http:4318",
+            ca_cert=None,
+            open_telemetry_stack_traces=False,
+            open_telemetry_sample_ratio=0.1,
+            open_telemetry_tail_sampling_threshold="1ms",
+            insecure_skip_verify=False,
+        )
+
+        harness.update_config({"open-telemetry-sample-ratio": 1.1})
+        self.assertEqual(mock_set_workload_tracing_config.call_count, 1)
+
+        harness.remove_relation(relation_id)
+
+        self.assertEqual(mock_set_workload_tracing_config.call_count, 2)
+        mock_set_workload_tracing_config.assert_called_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=None,
+        )
+        with patch.object(harness.charm, "api_port", return_value=17070):
+            harness.evaluate_status()
+        self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
+        self.assertEqual(
+            harness.charm.unit.status.message,
+            "invalid open-telemetry-sample-ratio: must be between 0 and 1",
+        )
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
     def test_workload_tracing_set_and_remove_do_not_change_charm_tracing(
         self,
         mock_set_workload_tracing_config,

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -219,7 +219,7 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
 
         event = type("Event", (), {"relation": object()})()
-        with patch.object(harness.charm.tracing_requirer, "is_ready", return_value=False):
+        with patch.object(harness.charm.charm_tracing_requirer, "is_ready", return_value=False):
             harness.charm._on_tracing_relation_changed(event)
 
         mock_set_tracing_config.assert_not_called()
@@ -231,6 +231,7 @@ class TestCharm(unittest.TestCase):
     ):
         harness = self.harness
         harness.set_leader(True)
+        harness.charm._stored.workload_tracing_status_error = None
         mock_set_tracing_config.reset_mock()
         mock_set_tracing_config.side_effect = SocketConnectionError("could not connect to socket")
 
@@ -254,6 +255,7 @@ class TestCharm(unittest.TestCase):
     def test_tracing_status_error_clears_after_success(self, mock_set_tracing_config, *_):
         harness = self.harness
         harness.set_leader(True)
+        harness.charm._stored.workload_tracing_status_error = None
         mock_set_tracing_config.reset_mock()
 
         relation_id = harness.add_relation("charm-tracing", "tempo-coordinator")
@@ -372,6 +374,354 @@ class TestCharm(unittest.TestCase):
             ca_cert=None,
         )
 
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_charm_tracing_set_and_remove_do_not_change_workload_tracing(
+        self,
+        mock_set_workload_tracing_config,
+        mock_set_charm_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_charm_tracing_config.reset_mock()
+        mock_set_workload_tracing_config.reset_mock()
+
+        relation_id = harness.add_relation("charm-tracing", "tempo-coordinator")
+        harness.add_relation_unit(relation_id, "tempo-coordinator/0")
+        harness.update_relation_data(
+            relation_id,
+            "tempo-coordinator",
+            tracing_provider_data(),
+        )
+        mock_set_charm_tracing_config.assert_called_once_with(
+            grpc_endpoint="tempo-grpc:4317",
+            http_endpoint="http://tempo-http:4318",
+            ca_cert=None,
+        )
+        mock_set_workload_tracing_config.assert_not_called()
+
+        harness.remove_relation(relation_id)
+        self.assertEqual(mock_set_charm_tracing_config.call_count, 2)
+        mock_set_charm_tracing_config.assert_called_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=None,
+        )
+        mock_set_workload_tracing_config.assert_not_called()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_workload_tracing_relation_updates_endpoints(
+        self,
+        mock_set_workload_tracing_config,
+        _mock_set_charm_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_workload_tracing_config.reset_mock()
+
+        relation_id = harness.add_relation("workload-tracing", "tempo-coordinator")
+        harness.add_relation_unit(relation_id, "tempo-coordinator/0")
+
+        harness.update_relation_data(
+            relation_id,
+            "tempo-coordinator",
+            tracing_provider_data(),
+        )
+
+        mock_set_workload_tracing_config.assert_called_once_with(
+            grpc_endpoint="tempo-grpc:4317",
+            http_endpoint="http://tempo-http:4318",
+            ca_cert=None,
+        )
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_workload_tracing_relation_cleared_on_leader_elected_without_relations(
+        self,
+        mock_set_workload_tracing_config,
+        _mock_set_charm_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+
+        harness.set_leader(True)
+
+        mock_set_workload_tracing_config.assert_called_once_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=None,
+        )
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_workload_tracing_relation_replayed_on_leader_elected(
+        self,
+        mock_set_workload_tracing_config,
+        _mock_set_charm_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+
+        relation_id = harness.add_relation("workload-tracing", "tempo-coordinator")
+        harness.add_relation_unit(relation_id, "tempo-coordinator/0")
+
+        harness.update_relation_data(
+            relation_id,
+            "tempo-coordinator",
+            tracing_provider_data(),
+        )
+
+        mock_set_workload_tracing_config.assert_not_called()
+
+        harness.set_leader(True)
+
+        mock_set_workload_tracing_config.assert_called_once_with(
+            grpc_endpoint="tempo-grpc:4317",
+            http_endpoint="http://tempo-http:4318",
+            ca_cert=None,
+        )
+
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_workload_tracing_relation_change_ignores_not_ready(
+        self, mock_set_workload_tracing_config
+    ):
+        harness = self.harness
+
+        event = type("Event", (), {"relation": object()})()
+        with patch.object(
+            harness.charm.workload_tracing_requirer, "is_ready", return_value=False
+        ):
+            harness.charm._on_workload_tracing_relation_changed(event)
+
+        mock_set_workload_tracing_config.assert_not_called()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_workload_tracing_relation_update_sets_blocked_on_socket_error(
+        self,
+        mock_set_workload_tracing_config,
+        _mock_set_charm_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_workload_tracing_config.reset_mock()
+        mock_set_workload_tracing_config.side_effect = SocketConnectionError(
+            "could not connect to socket"
+        )
+
+        relation_id = harness.add_relation("workload-tracing", "tempo-coordinator")
+        harness.add_relation_unit(relation_id, "tempo-coordinator/0")
+
+        harness.update_relation_data(
+            relation_id,
+            "tempo-coordinator",
+            tracing_provider_data(),
+        )
+
+        with patch.object(harness.charm, "api_port", return_value=17070):
+            harness.evaluate_status()
+
+        self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
+        self.assertEqual(
+            harness.charm.unit.status.message, "failed to set workload tracing config"
+        )
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_workload_tracing_status_error_clears_after_success(
+        self,
+        mock_set_workload_tracing_config,
+        _mock_set_charm_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_workload_tracing_config.reset_mock()
+
+        relation_id = harness.add_relation("workload-tracing", "tempo-coordinator")
+        harness.add_relation_unit(relation_id, "tempo-coordinator/0")
+
+        mock_set_workload_tracing_config.side_effect = [
+            SocketConnectionError("could not connect to socket"),
+            None,
+        ]
+        harness.update_relation_data(
+            relation_id,
+            "tempo-coordinator",
+            tracing_provider_data(),
+        )
+        with patch.object(harness.charm, "api_port", return_value=17070):
+            harness.evaluate_status()
+        self.assertEqual(
+            harness.charm.unit.status.message, "failed to set workload tracing config"
+        )
+
+        harness.remove_relation(relation_id)
+        with patch.object(harness.charm, "api_port", return_value=17070):
+            harness.evaluate_status()
+        self.assertIsInstance(harness.charm.unit.status, ActiveStatus)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_workload_tracing_relation_removed_clears_endpoints(
+        self,
+        mock_set_workload_tracing_config,
+        _mock_set_charm_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_workload_tracing_config.reset_mock()
+
+        relation_id = harness.add_relation("workload-tracing", "tempo-coordinator")
+        harness.add_relation_unit(relation_id, "tempo-coordinator/0")
+
+        harness.update_relation_data(
+            relation_id,
+            "tempo-coordinator",
+            tracing_provider_data(),
+        )
+        mock_set_workload_tracing_config.assert_called_once_with(
+            grpc_endpoint="tempo-grpc:4317",
+            http_endpoint="http://tempo-http:4318",
+            ca_cert=None,
+        )
+
+        harness.remove_relation(relation_id)
+
+        self.assertEqual(mock_set_workload_tracing_config.call_count, 2)
+        mock_set_workload_tracing_config.assert_called_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=None,
+        )
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_workload_tracing_set_and_remove_do_not_change_charm_tracing(
+        self,
+        mock_set_workload_tracing_config,
+        mock_set_charm_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_charm_tracing_config.reset_mock()
+        mock_set_workload_tracing_config.reset_mock()
+
+        relation_id = harness.add_relation("workload-tracing", "tempo-coordinator")
+        harness.add_relation_unit(relation_id, "tempo-coordinator/0")
+        harness.update_relation_data(
+            relation_id,
+            "tempo-coordinator",
+            tracing_provider_data(),
+        )
+        mock_set_workload_tracing_config.assert_called_once_with(
+            grpc_endpoint="tempo-grpc:4317",
+            http_endpoint="http://tempo-http:4318",
+            ca_cert=None,
+        )
+        mock_set_charm_tracing_config.assert_not_called()
+
+        harness.remove_relation(relation_id)
+        self.assertEqual(mock_set_workload_tracing_config.call_count, 2)
+        mock_set_workload_tracing_config.assert_called_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=None,
+        )
+        mock_set_charm_tracing_config.assert_not_called()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_receive_workload_ca_cert_updates_tracing_config(
+        self,
+        mock_set_workload_tracing_config,
+        _mock_set_charm_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_workload_tracing_config.reset_mock()
+
+        relation_id = harness.add_relation("workload-tracing-ca-cert", "cert-provider")
+        harness.add_relation_unit(relation_id, "cert-provider/0")
+
+        cert_a = "-----BEGIN CERTIFICATE-----\na\n-----END CERTIFICATE-----"
+        cert_b = "-----BEGIN CERTIFICATE-----\nb\n-----END CERTIFICATE-----"
+        harness.update_relation_data(
+            relation_id,
+            "cert-provider",
+            certificate_provider_data({cert_b, cert_a}),
+        )
+
+        mock_set_workload_tracing_config.assert_called_once_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert="\n".join([cert_a, cert_b]),
+        )
+
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_receive_workload_ca_cert_update_ignores_empty_cert_list(
+        self, mock_set_workload_tracing_config
+    ):
+        harness = self.harness
+
+        event = type("Event", (), {"certificates": set(), "relation_id": 1})()
+        harness.charm._on_receive_workload_ca_cert_updated(event)
+
+        mock_set_workload_tracing_config.assert_not_called()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
+    @patch("controlsocket.ControlSocketClient.set_workload_tracing_config")
+    def test_receive_workload_ca_cert_removed_clears_tracing_ca_cert(
+        self,
+        mock_set_workload_tracing_config,
+        _mock_set_charm_tracing_config,
+        *_,
+    ):
+        harness = self.harness
+        harness.set_leader(True)
+        mock_set_workload_tracing_config.reset_mock()
+
+        relation_id = harness.add_relation("workload-tracing-ca-cert", "cert-provider")
+        harness.add_relation_unit(relation_id, "cert-provider/0")
+
+        cert = "-----BEGIN CERTIFICATE-----\na\n-----END CERTIFICATE-----"
+        harness.update_relation_data(
+            relation_id,
+            "cert-provider",
+            certificate_provider_data({cert}),
+        )
+        mock_set_workload_tracing_config.assert_called_once_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=cert,
+        )
+
+        harness.remove_relation(relation_id)
+
+        self.assertEqual(mock_set_workload_tracing_config.call_count, 2)
+        mock_set_workload_tracing_config.assert_called_with(
+            grpc_endpoint=None,
+            http_endpoint=None,
+            ca_cert=None,
+        )
+
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf_apiaddresses_missing)
     def test_apiaddresses_missing(self, _):
         harness = self.harness
@@ -426,6 +776,7 @@ class TestCharm(unittest.TestCase):
 
         harness.set_leader()
         harness.charm._stored.tracing_status_error = None
+        harness.charm._stored.workload_tracing_status_error = None
 
         # Have another unit enter the relation.
         # Its bind address should end up in the application data bindings list.
@@ -526,6 +877,7 @@ class TestCharm(unittest.TestCase):
 
         harness.set_leader()
         harness.charm._stored.tracing_status_error = None
+        harness.charm._stored.workload_tracing_status_error = None
 
         # Have another unit enter the relation.
         relation_id = harness.add_relation('dbcluster', harness.charm.app.name)
@@ -557,6 +909,7 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         harness.set_leader(True)
         harness.charm._stored.tracing_status_error = None
+        harness.charm._stored.workload_tracing_status_error = None
 
         relation_id = harness.add_relation("s3-backend", "s3-integrator")
         harness.add_relation_unit(relation_id, "s3-integrator/0")
@@ -587,6 +940,7 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         harness.set_leader(True)
         harness.charm._stored.tracing_status_error = None
+        harness.charm._stored.workload_tracing_status_error = None
 
         relation_id = harness.add_relation("s3-backend", "s3-integrator")
         harness.add_relation_unit(relation_id, "s3-integrator/0")
@@ -616,6 +970,7 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         harness.set_leader(True)
         harness.charm._stored.tracing_status_error = None
+        harness.charm._stored.workload_tracing_status_error = None
 
         relation_id = harness.add_relation("s3-backend", "s3-integrator")
         harness.add_relation_unit(relation_id, "s3-integrator/0")
@@ -695,6 +1050,7 @@ class TestCharm(unittest.TestCase):
 
         harness.set_leader(True)
         harness.charm._stored.tracing_status_error = None
+        harness.charm._stored.workload_tracing_status_error = None
         with patch.object(harness.charm, "api_port", return_value=17070):
             harness.evaluate_status()
         self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
@@ -705,6 +1061,7 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         harness.set_leader(True)
         harness.charm._stored.tracing_status_error = None
+        harness.charm._stored.workload_tracing_status_error = None
 
         relation_id = harness.add_relation("s3-backend", "s3-integrator")
         harness.add_relation_unit(relation_id, "s3-integrator/0")
@@ -786,6 +1143,7 @@ class TestCharm(unittest.TestCase):
         harness = self.harness
         harness.set_leader(True)
         harness.charm._stored.tracing_status_error = None
+        harness.charm._stored.workload_tracing_status_error = None
 
         relation_id = harness.add_relation("s3-backend", "s3-integrator")
         harness.add_relation_unit(relation_id, "s3-integrator/0")

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -99,7 +99,10 @@ class TestClass(unittest.TestCase):
             body=(
                 r'{"grpc_endpoint": "grpc://trace.example.com:4317", '
                 r'"http_endpoint": "http://trace.example.com:4318", '
-                r'"ca_cert": "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----"}'
+                r'"ca_cert": "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----", '
+                r'"open_telemetry_stack_traces": true, '
+                r'"open_telemetry_sample_ratio": 0.5, '
+                r'"open_telemetry_tail_sampling_threshold": "250ms"}'
             ),
             response=MockResponse(
                 headers=MockHeaders(content_type='application/json'),
@@ -111,6 +114,9 @@ class TestClass(unittest.TestCase):
             grpc_endpoint='grpc://trace.example.com:4317',
             http_endpoint='http://trace.example.com:4318',
             ca_cert='-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----',
+            open_telemetry_stack_traces=True,
+            open_telemetry_sample_ratio=0.5,
+            open_telemetry_tail_sampling_threshold='250ms',
         )
 
     def test_set_workload_tracing_config_success(self):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -99,10 +99,7 @@ class TestClass(unittest.TestCase):
             body=(
                 r'{"grpc_endpoint": "grpc://trace.example.com:4317", '
                 r'"http_endpoint": "http://trace.example.com:4318", '
-                r'"ca_cert": "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----", '
-                r'"open_telemetry_stack_traces": true, '
-                r'"open_telemetry_sample_ratio": 0.5, '
-                r'"open_telemetry_tail_sampling_threshold": "250ms"}'
+                r'"ca_cert": "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----"}'
             ),
             response=MockResponse(
                 headers=MockHeaders(content_type='application/json'),
@@ -114,9 +111,6 @@ class TestClass(unittest.TestCase):
             grpc_endpoint='grpc://trace.example.com:4317',
             http_endpoint='http://trace.example.com:4318',
             ca_cert='-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----',
-            open_telemetry_stack_traces=True,
-            open_telemetry_sample_ratio=0.5,
-            open_telemetry_tail_sampling_threshold='250ms',
         )
 
     def test_set_workload_tracing_config_success(self):
@@ -129,7 +123,11 @@ class TestClass(unittest.TestCase):
             body=(
                 r'{"grpc_endpoint": "grpc://trace.example.com:4317", '
                 r'"http_endpoint": "http://trace.example.com:4318", '
-                r'"ca_cert": "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----"}'
+                r'"ca_cert": "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----", '
+                r'"open_telemetry_stack_traces": true, '
+                r'"open_telemetry_sample_ratio": 0.5, '
+                r'"open_telemetry_tail_sampling_threshold": "250ms", '
+                r'"insecure_skip_verify": true}'
             ),
             response=MockResponse(
                 headers=MockHeaders(content_type='application/json'),
@@ -141,6 +139,10 @@ class TestClass(unittest.TestCase):
             grpc_endpoint='grpc://trace.example.com:4317',
             http_endpoint='http://trace.example.com:4318',
             ca_cert='-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----',
+            open_telemetry_stack_traces=True,
+            open_telemetry_sample_ratio=0.5,
+            open_telemetry_tail_sampling_threshold='250ms',
+            insecure_skip_verify=True,
         )
 
     def test_connection_error(self):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -113,6 +113,30 @@ class TestClass(unittest.TestCase):
             ca_cert='-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----',
         )
 
+    def test_set_workload_tracing_config_success(self):
+        mock_opener = MockOpener(self)
+        control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
+
+        mock_opener.expect(
+            url='http://localhost/workload-tracing-config',
+            method='POST',
+            body=(
+                r'{"grpc_endpoint": "grpc://trace.example.com:4317", '
+                r'"http_endpoint": "http://trace.example.com:4318", '
+                r'"ca_cert": "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----"}'
+            ),
+            response=MockResponse(
+                headers=MockHeaders(content_type='application/json'),
+                body=r'{"message":"updated workload tracing config"}'
+            )
+        )
+
+        control_socket.set_workload_tracing_config(
+            grpc_endpoint='grpc://trace.example.com:4317',
+            http_endpoint='http://trace.example.com:4318',
+            ca_cert='-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----',
+        )
+
     def test_connection_error(self):
         mock_opener = MockOpener(self)
         control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)


### PR DESCRIPTION
Tightens controller configuration behavior in HA scenarios.
On leadership changes or delayed relation/config events, stale tracing state can be replayed or config issues can be hard to spot. The goal is to make reconciliation deterministic on the active leader and make configuration problems immediately visible to operators.

High-level changes

 - Tracing/S3/workload tracing reconciliation now consistently uses current state during leader and config transitions.
 - Charm tracing and workload tracing are handled independently to avoid cross-impact.
 - OpenTelemetry config propagation was extended, including validation for sample ratio (0..1) with clear blocked status on invalid or failed apply.
 - Test coverage was expanded for HA replay/clear paths and config-error status visibility