### PR TITLE
refactor: update config names

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,17 +14,17 @@ options:
     default: true
     description: Whether this is a standalone Juju controller
     type: boolean
-  open-telemetry-stack-traces:
+  workload-tracing-stack-traces:
     default: false
-    description: Whether stack traces should be added per OpenTelemetry span.
+    description: Whether stack traces should be added per workload tracing span.
     type: boolean
-  open-telemetry-sample-ratio:
+  workload-tracing-sample-ratio:
     default: 0.1
-    description: The OpenTelemetry sampling ratio (must be between 0 and 1).
+    description: The workload tracing sampling ratio (must be between 0 and 1).
     type: float
-  open-telemetry-tail-sampling-threshold:
+  workload-tracing-tail-sampling-threshold:
     default: "1ms"
-    description: The OpenTelemetry tail sampling threshold as a duration string.
+    description: The workload tracing tail sampling threshold as a duration string.
     type: string
   workload-tracing-insecure-skip-verify:
     default: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -553,16 +553,16 @@ class JujuControllerCharm(CharmBase):
     def _validate_open_telemetry_sample_ratio(self, sample_ratio: float):
         if sample_ratio < 0 or sample_ratio > 1:
             raise ValueError(
-                "invalid open-telemetry-sample-ratio: must be between 0 and 1"
+                "invalid workload-tracing-sample-ratio: must be between 0 and 1"
             )
 
     def _current_open_telemetry_config(self) -> Tuple[bool, float, str, bool]:
-        sample_ratio = float(self.config["open-telemetry-sample-ratio"])
+        sample_ratio = float(self.config["workload-tracing-sample-ratio"])
         self._validate_open_telemetry_sample_ratio(sample_ratio)
         return (
-            self.config["open-telemetry-stack-traces"],
+            self.config["workload-tracing-stack-traces"],
             sample_ratio,
-            self.config["open-telemetry-tail-sampling-threshold"],
+            self.config["workload-tracing-tail-sampling-threshold"],
             self.config["workload-tracing-insecure-skip-verify"],
         )
 
@@ -612,9 +612,9 @@ class JujuControllerCharm(CharmBase):
                 insecure_skip_verify,
             ) = self._current_open_telemetry_config()
             open_telemetry_config = {
-                "open_telemetry_stack_traces": open_telemetry_stack_traces,
-                "open_telemetry_sample_ratio": open_telemetry_sample_ratio,
-                "open_telemetry_tail_sampling_threshold": open_telemetry_tail_sampling_threshold,
+                "stack_traces": open_telemetry_stack_traces,
+                "sample_ratio": open_telemetry_sample_ratio,
+                "tail_sampling_threshold": open_telemetry_tail_sampling_threshold,
                 "insecure_skip_verify": insecure_skip_verify,
             }
         except ValueError as exc:

--- a/src/controlsocket.py
+++ b/src/controlsocket.py
@@ -57,9 +57,9 @@ class ControlSocketClient(unixsocket.SocketClient):
         grpc_endpoint: Optional[str],
         http_endpoint: Optional[str],
         ca_cert: Optional[str],
-        open_telemetry_stack_traces: Optional[bool] = None,
-        open_telemetry_sample_ratio: Optional[float] = None,
-        open_telemetry_tail_sampling_threshold: Optional[str] = None,
+        stack_traces: Optional[bool] = None,
+        sample_ratio: Optional[float] = None,
+        tail_sampling_threshold: Optional[str] = None,
         insecure_skip_verify: Optional[bool] = None,
     ):
         """Set the tracing configuration for the controller workload."""
@@ -68,13 +68,13 @@ class ControlSocketClient(unixsocket.SocketClient):
             "http_endpoint": http_endpoint,
             "ca_cert": ca_cert,
         }
-        if open_telemetry_stack_traces is not None:
-            body["open_telemetry_stack_traces"] = open_telemetry_stack_traces
-        if open_telemetry_sample_ratio is not None:
-            body["open_telemetry_sample_ratio"] = open_telemetry_sample_ratio
-        if open_telemetry_tail_sampling_threshold is not None:
-            body["open_telemetry_tail_sampling_threshold"] = (
-                open_telemetry_tail_sampling_threshold
+        if stack_traces is not None:
+            body["stack_traces"] = stack_traces
+        if sample_ratio is not None:
+            body["sample_ratio"] = sample_ratio
+        if tail_sampling_threshold is not None:
+            body["tail_sampling_threshold"] = (
+                tail_sampling_threshold
             )
         if insecure_skip_verify is not None:
             body["insecure_skip_verify"] = insecure_skip_verify

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -456,9 +456,9 @@ class TestCharm(unittest.TestCase):
 
         harness.update_config(
             {
-                "open-telemetry-stack-traces": True,
-                "open-telemetry-sample-ratio": 0.5,
-                "open-telemetry-tail-sampling-threshold": "250ms",
+                "workload-tracing-stack-traces": True,
+                "workload-tracing-sample-ratio": 0.5,
+                "workload-tracing-tail-sampling-threshold": "250ms",
                 "workload-tracing-insecure-skip-verify": True,
             }
         )
@@ -469,9 +469,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=True,
-            open_telemetry_sample_ratio=0.5,
-            open_telemetry_tail_sampling_threshold="250ms",
+            stack_traces=True,
+            sample_ratio=0.5,
+            tail_sampling_threshold="250ms",
             insecure_skip_verify=True,
         )
 
@@ -516,9 +516,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
         self.assertEqual(mock_set_loki_endpoint.call_count, 1)
@@ -572,9 +572,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
         self.assertEqual(mock_set_loki_endpoint.call_count, 1)
@@ -601,7 +601,7 @@ class TestCharm(unittest.TestCase):
         mock_set_charm_tracing_config.reset_mock()
         mock_set_workload_tracing_config.reset_mock()
 
-        harness.update_config({"open-telemetry-sample-ratio": 1.1})
+        harness.update_config({"workload-tracing-sample-ratio": 1.1})
 
         mock_set_charm_tracing_config.assert_not_called()
         mock_set_workload_tracing_config.assert_not_called()
@@ -610,7 +610,7 @@ class TestCharm(unittest.TestCase):
         self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
         self.assertEqual(
             harness.charm.unit.status.message,
-            "invalid open-telemetry-sample-ratio: must be between 0 and 1",
+            "invalid workload-tracing-sample-ratio: must be between 0 and 1",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -627,25 +627,25 @@ class TestCharm(unittest.TestCase):
         mock_set_charm_tracing_config.reset_mock()
         mock_set_workload_tracing_config.reset_mock()
 
-        harness.update_config({"open-telemetry-sample-ratio": 1.1})
+        harness.update_config({"workload-tracing-sample-ratio": 1.1})
         with patch.object(harness.charm, "api_port", return_value=17070):
             harness.evaluate_status()
         self.assertEqual(
             harness.charm.unit.status.message,
-            "invalid open-telemetry-sample-ratio: must be between 0 and 1",
+            "invalid workload-tracing-sample-ratio: must be between 0 and 1",
         )
         mock_set_charm_tracing_config.assert_not_called()
 
-        harness.update_config({"open-telemetry-sample-ratio": 0.25})
+        harness.update_config({"workload-tracing-sample-ratio": 0.25})
 
         mock_set_charm_tracing_config.assert_not_called()
         mock_set_workload_tracing_config.assert_called_once_with(
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.25,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.25,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
         with patch.object(harness.charm, "api_port", return_value=17070):
@@ -669,15 +669,15 @@ class TestCharm(unittest.TestCase):
         _mock_set_charm_tracing_config.reset_mock()
         mock_set_workload_tracing_config.reset_mock()
 
-        harness.update_config({"open-telemetry-sample-ratio": 0.5})
+        harness.update_config({"workload-tracing-sample-ratio": 0.5})
 
         mock_set_workload_tracing_config.assert_called_once_with(
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.5,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.5,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
         with patch.object(harness.charm, "api_port", return_value=17070):
@@ -706,7 +706,7 @@ class TestCharm(unittest.TestCase):
             SocketConnectionError("could not connect to socket"),
             None,
         ]
-        harness.update_config({"open-telemetry-sample-ratio": 0.5})
+        harness.update_config({"workload-tracing-sample-ratio": 0.5})
 
         with patch.object(harness.charm, "api_port", return_value=17070):
             harness.evaluate_status()
@@ -715,7 +715,7 @@ class TestCharm(unittest.TestCase):
             "failed to set workload tracing config",
         )
 
-        harness.update_config({"open-telemetry-stack-traces": True})
+        harness.update_config({"workload-tracing-stack-traces": True})
         with patch.object(harness.charm, "api_port", return_value=17070):
             harness.evaluate_status()
         self.assertIsInstance(harness.charm.unit.status, ActiveStatus)
@@ -784,9 +784,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
 
@@ -807,9 +807,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
 
@@ -841,9 +841,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
 
@@ -928,9 +928,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="https://tempo-http:4318",
             ca_cert=cert,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
         with patch.object(harness.charm, "api_port", return_value=17070):
@@ -964,9 +964,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="https://tempo-http:4318",
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=True,
         )
 
@@ -1064,9 +1064,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
 
@@ -1077,9 +1077,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
 
@@ -1108,13 +1108,13 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
 
-        harness.update_config({"open-telemetry-sample-ratio": 1.1})
+        harness.update_config({"workload-tracing-sample-ratio": 1.1})
         self.assertEqual(mock_set_workload_tracing_config.call_count, 1)
 
         harness.remove_relation(relation_id)
@@ -1130,7 +1130,7 @@ class TestCharm(unittest.TestCase):
         self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
         self.assertEqual(
             harness.charm.unit.status.message,
-            "invalid open-telemetry-sample-ratio: must be between 0 and 1",
+            "invalid workload-tracing-sample-ratio: must be between 0 and 1",
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
@@ -1158,9 +1158,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint="tempo-grpc:4317",
             http_endpoint="http://tempo-http:4318",
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
         mock_set_charm_tracing_config.assert_not_called()
@@ -1171,9 +1171,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
         mock_set_charm_tracing_config.assert_not_called()
@@ -1206,9 +1206,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert="\n".join([cert_a, cert_b]),
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
 
@@ -1249,9 +1249,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=cert,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
 
@@ -1262,9 +1262,9 @@ class TestCharm(unittest.TestCase):
             grpc_endpoint=None,
             http_endpoint=None,
             ca_cert=None,
-            open_telemetry_stack_traces=False,
-            open_telemetry_sample_ratio=0.1,
-            open_telemetry_tail_sampling_threshold="1ms",
+            stack_traces=False,
+            sample_ratio=0.1,
+            tail_sampling_threshold="1ms",
             insecure_skip_verify=False,
         )
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -124,9 +124,9 @@ class TestClass(unittest.TestCase):
                 r'{"grpc_endpoint": "grpc://trace.example.com:4317", '
                 r'"http_endpoint": "http://trace.example.com:4318", '
                 r'"ca_cert": "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----", '
-                r'"open_telemetry_stack_traces": true, '
-                r'"open_telemetry_sample_ratio": 0.5, '
-                r'"open_telemetry_tail_sampling_threshold": "250ms", '
+                r'"stack_traces": true, '
+                r'"sample_ratio": 0.5, '
+                r'"tail_sampling_threshold": "250ms", '
                 r'"insecure_skip_verify": true}'
             ),
             response=MockResponse(
@@ -139,9 +139,9 @@ class TestClass(unittest.TestCase):
             grpc_endpoint='grpc://trace.example.com:4317',
             http_endpoint='http://trace.example.com:4318',
             ca_cert='-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----',
-            open_telemetry_stack_traces=True,
-            open_telemetry_sample_ratio=0.5,
-            open_telemetry_tail_sampling_threshold='250ms',
+            stack_traces=True,
+            sample_ratio=0.5,
+            tail_sampling_threshold='250ms',
             insecure_skip_verify=True,
         )
 


### PR DESCRIPTION
The config names were the same as the controller config, but they're not the same as the controller now they're in the controller charm.

Fixing this makes the charm feel consistent. We can do this, because we've not released the charm.