### PR TITLE
feat: loki alert rules

### DIFF
--- a/src/loki_alert_rules/juju_controller_alerts.yaml
+++ b/src/loki_alert_rules/juju_controller_alerts.yaml
@@ -1,0 +1,45 @@
+groups:
+  - name: juju-controller-alerts
+    rules:
+      - alert: JujuControllerHighErrorRate
+        expr: |
+          sum(rate({%%juju_topology%%} |= "ERROR" [5m])) by (juju_model, juju_model_uuid, juju_application)
+            /
+          sum(rate({%%juju_topology%%}[5m])) by (juju_model, juju_model_uuid, juju_application)
+            > 0.05
+        for: 10m
+        labels:
+          severity: page
+        annotations:
+          summary: Juju controller high error rate
+          description: |
+            More than 5% of Juju controller log lines in the last 10 minutes
+            contain "ERROR". This may indicate operational issues with the
+            controller, such as failed API requests, model errors, or
+            database connectivity problems.
+
+      - alert: JujuControllerFatalError
+        expr: |
+          sum(count_over_time({%%juju_topology%%} |~ "(?i)FATAL|panic" [5m])) by (juju_model, juju_model_uuid, juju_application) > 0
+        for: 1m
+        labels:
+          severity: page
+        annotations:
+          summary: Juju controller fatal error or panic
+          description: |
+            The Juju controller has logged a FATAL error or panic in the last
+            5 minutes. This indicates a critical failure that may require
+            immediate investigation.
+
+      - alert: JujuControllerLogsStopped
+        expr: |
+          sum(count_over_time({%%juju_topology%%}[10m])) by (juju_model, juju_model_uuid, juju_application) == 0
+        for: 15m
+        labels:
+          severity: page
+        annotations:
+          summary: Juju controller stopped sending logs
+          description: |
+            No logs have been received from the Juju controller for more
+            than 15 minutes. This may indicate that the controller is down
+            or that logging has been misconfigured.


### PR DESCRIPTION
The Juju controller charm forwards its workload logs to Loki via the loki-push-api relation, and the LokiPushApiConsumer library defaults to forwarding alert rules from `./src/loki_alert_rules/`.

Adds `src/loki_alert_rules/juju_controller_alerts.yaml` with three LogQL alert rules, each scoped to the charm's Juju topology via the `%%juju_topology%%` placeholder (automatically resolved by the library):

- JujuControllerHighErrorRate — fires when >5% of controller log lines contain ERROR over a 10-minute window. Catches sustained operational issues like failed API requests, model errors, or database connectivity problems.
- JujuControllerFatalError — fires when the controller logs a FATAL error or panic. Indicates a critical failure warranting immediate investigation.
- JujuControllerLogsStopped — fires when no logs are received from the controller for 15 minutes. Catches controller outages or logging misconfiguration that might otherwise go unnoticed.