### PR TITLE
feat: consume bucket and region

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -148,7 +148,7 @@ class JujuControllerCharm(CharmBase):
             self._on_receive_workload_ca_cert_removed,
         )
         # S3 credential events are observed to maintain the current S3
-        # credentials in the charm's stored state, and to apply them via the
+        # config in the charm's stored state, and to apply it via the
         # control socket when they change.
         self.framework.observe(
             self._s3.on.credentials_changed, self._on_s3_credentials_changed)
@@ -188,32 +188,19 @@ class JujuControllerCharm(CharmBase):
         self._update_workload_tracing_config()
         self._reconcile_loki_endpoint()
 
-        # Read current relation data rather than relying on locally cached
-        # state. This avoids replaying stale credentials if this unit becomes
-        # leader before processing delayed relation events.
-        s3_connection_info = self._s3.get_s3_connection_info()
-        access_key = s3_connection_info.get("access-key")
-        secret_key = s3_connection_info.get("secret-key")
-        if not access_key or not secret_key:
+        config = self._current_s3_config()
+        if config is None:
             return
-
-        config = {
-            "access_key": access_key,
-            "secret_key": secret_key,
-            "bucket": s3_connection_info.get("bucket"),
-            "region": s3_connection_info.get("region"),
-            "endpoint": s3_connection_info.get("endpoint"),
-        }
         self._stored.s3_status_pending = True
 
         try:
-            logger.info("reapplying S3 credentials after leadership change")
+            logger.info("reapplying S3 config after leadership change")
             self._control_socket.add_s3_config(config)
             self._stored.s3_status_error = None
         except Exception as exc:  # pragma: no cover - defensive
-            logger.error("failed to reapply S3 credentials after leadership change: %s", exc)
+            logger.error("failed to reapply S3 config after leadership change: %s", exc)
             self._stored.s3_status_pending = False
-            self._stored.s3_status_error = "failed to reapply s3 credentials"
+            self._stored.s3_status_error = "failed to reapply s3 config"
 
     def _on_collect_status(self, event: CollectStatusEvent):
         has_blocking_status = False
@@ -247,7 +234,7 @@ class JujuControllerCharm(CharmBase):
 
         if self._stored.s3_status_pending:
             if not has_blocking_status:
-                event.add_status(MaintenanceStatus("applying s3 credentials"))
+                event.add_status(MaintenanceStatus("applying s3 config"))
             self._stored.s3_status_pending = False
             return
 
@@ -568,6 +555,26 @@ class JujuControllerCharm(CharmBase):
             self.config["workload-tracing-insecure-skip-verify"],
         )
 
+    def _current_s3_config(self):
+        # Read current relation data rather than relying on locally cached
+        # state. This avoids replaying stale config if this unit becomes leader
+        # before processing delayed relation events.
+        s3_connection_info = self._s3.get_s3_connection_info()
+        access_key = s3_connection_info.get("access-key")
+        secret_key = s3_connection_info.get("secret-key")
+        if not access_key or not secret_key:
+            return None
+
+        # Juju's current socket path is still credentials-specific, but the
+        # payload is full S3 config. Optional values may be explicit nulls.
+        return {
+            "access_key": access_key,
+            "secret_key": secret_key,
+            "bucket": s3_connection_info.get("bucket"),
+            "region": s3_connection_info.get("region"),
+            "endpoint": s3_connection_info.get("endpoint"),
+        }
+
     def _update_charm_tracing_config(self):
         """Update charm configuration with current tracing endpoint and CA cert information."""
         if not self.unit.is_leader():
@@ -652,31 +659,27 @@ class JujuControllerCharm(CharmBase):
             logger.error("failed to set workload tracing config: %s", exc)
             self._stored.workload_tracing_status_error = "failed to set workload tracing config"
 
-    def _on_s3_credentials_changed(self, event: CredentialsChangedEvent):
-        """Handle new or updated S3 credentials."""
-        config = {
-            'access_key': event.access_key,
-            'secret_key': event.secret_key,
-            'bucket': event.bucket,
-            'region': event.region,
-            'endpoint': event.endpoint,
-        }
+    def _on_s3_credentials_changed(self, _event: CredentialsChangedEvent):
+        """Handle new or updated S3 config."""
+        config = self._current_s3_config()
+        if config is None:
+            return
 
         if not self.unit.is_leader():
             return
 
         self._stored.s3_status_pending = True
         try:
-            logger.info("applying new S3 credentials")
+            logger.info("applying new S3 config")
             self._control_socket.add_s3_config(config)
             self._stored.s3_status_error = None
         except Exception as exc:  # pragma: no cover - defensive
-            logger.error("failed to apply S3 credentials: %s", exc)
+            logger.error("failed to apply S3 config: %s", exc)
             self._stored.s3_status_pending = False
-            self._stored.s3_status_error = "failed to apply s3 credentials"
+            self._stored.s3_status_error = "failed to apply s3 config"
 
     def _on_s3_credentials_gone(self, _event):
-        """Handle removal of S3 credentials."""
+        """Handle removal of S3 config."""
         if not self.unit.is_leader():
             return
 
@@ -684,8 +687,8 @@ class JujuControllerCharm(CharmBase):
             self._control_socket.remove_s3_config()
             self._stored.s3_status_error = None
         except Exception as exc:  # pragma: no cover - defensive
-            logger.error("failed to remove S3 credentials: %s", exc)
-            self._stored.s3_status_error = "failed to remove s3 credentials"
+            logger.error("failed to remove S3 config: %s", exc)
+            self._stored.s3_status_error = "failed to remove s3 config"
 
     def _on_loki_push_api_endpoint_joined(self, _event):
         """Handle new or updated Loki push API endpoint."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -197,16 +197,18 @@ class JujuControllerCharm(CharmBase):
         if not access_key or not secret_key:
             return
 
-        credentials = {
+        config = {
             "access_key": access_key,
             "secret_key": secret_key,
+            "bucket": s3_connection_info.get("bucket"),
+            "region": s3_connection_info.get("region"),
             "endpoint": s3_connection_info.get("endpoint"),
         }
         self._stored.s3_status_pending = True
 
         try:
             logger.info("reapplying S3 credentials after leadership change")
-            self._control_socket.add_s3_credentials(credentials)
+            self._control_socket.add_s3_config(config)
             self._stored.s3_status_error = None
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("failed to reapply S3 credentials after leadership change: %s", exc)
@@ -652,12 +654,11 @@ class JujuControllerCharm(CharmBase):
 
     def _on_s3_credentials_changed(self, event: CredentialsChangedEvent):
         """Handle new or updated S3 credentials."""
-        # S3Requirer always negotiates a bucket, but right now each controller
-        # uses its own Juju-managed bucket. We only need auth and endpoint
-        # until we support shared or externally managed buckets.
-        credentials = {
+        config = {
             'access_key': event.access_key,
             'secret_key': event.secret_key,
+            'bucket': event.bucket,
+            'region': event.region,
             'endpoint': event.endpoint,
         }
 
@@ -667,7 +668,7 @@ class JujuControllerCharm(CharmBase):
         self._stored.s3_status_pending = True
         try:
             logger.info("applying new S3 credentials")
-            self._control_socket.add_s3_credentials(credentials)
+            self._control_socket.add_s3_config(config)
             self._stored.s3_status_error = None
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("failed to apply S3 credentials: %s", exc)
@@ -680,7 +681,7 @@ class JujuControllerCharm(CharmBase):
             return
 
         try:
-            self._control_socket.remove_s3_credentials()
+            self._control_socket.remove_s3_config()
             self._stored.s3_status_error = None
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("failed to remove S3 credentials: %s", exc)

--- a/src/controlsocket.py
+++ b/src/controlsocket.py
@@ -85,20 +85,20 @@ class ControlSocketClient(unixsocket.SocketClient):
         )
         logger.debug('result of set_workload_tracing_config request: %r', resp)
 
-    def add_s3_credentials(self, credentials: dict):
+    def add_s3_config(self, config: dict):
         resp = self.json_request(
             method='POST',
             path='/s3-credentials',
-            body=credentials,
+            body=config,
         )
-        logger.debug('result of add_s3_credentials request: %r', resp)
+        logger.debug('result of add_s3_config request: %r', resp)
 
-    def remove_s3_credentials(self):
+    def remove_s3_config(self):
         resp = self.json_request(
             method='DELETE',
             path='/s3-credentials',
         )
-        logger.debug('result of remove_s3_credentials request: %r', resp)
+        logger.debug('result of remove_s3_config request: %r', resp)
 
     def set_loki_endpoint(self, endpoint: dict):
         resp = self.json_request(

--- a/src/controlsocket.py
+++ b/src/controlsocket.py
@@ -88,7 +88,7 @@ class ControlSocketClient(unixsocket.SocketClient):
     def add_s3_config(self, config: dict):
         resp = self.json_request(
             method='POST',
-            path='/s3-credentials',
+            path='/s3-config',
             body=config,
         )
         logger.debug('result of add_s3_config request: %r', resp)
@@ -96,7 +96,7 @@ class ControlSocketClient(unixsocket.SocketClient):
     def remove_s3_config(self):
         resp = self.json_request(
             method='DELETE',
-            path='/s3-credentials',
+            path='/s3-config',
         )
         logger.debug('result of remove_s3_config request: %r', resp)
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1545,8 +1545,36 @@ class TestCharm(unittest.TestCase):
             harness.evaluate_status()
         self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
         self.assertIn(
-            "failed to apply s3 credentials",
+            "failed to apply s3 config",
             harness.charm.unit.status.message,
+        )
+
+    @patch("controlsocket.ControlSocketClient.add_s3_config")
+    def test_s3_relation_credentials_changed_without_region(self, mock_add_s3_config):
+        harness = self.harness
+        harness.set_leader(True)
+
+        relation_id = harness.add_relation("s3-backend", "s3-integrator")
+        harness.add_relation_unit(relation_id, "s3-integrator/0")
+
+        harness.update_relation_data(
+            relation_id,
+            "s3-integrator",
+            {
+                "access-key": "ak",
+                "secret-key": "sk",
+                "bucket": "test-bucket",
+            },
+        )
+
+        mock_add_s3_config.assert_called_once_with(
+            {
+                "access_key": "ak",
+                "secret_key": "sk",
+                "bucket": "test-bucket",
+                "region": None,
+                "endpoint": None,
+            }
         )
 
     @patch("controlsocket.ControlSocketClient.add_s3_config")
@@ -1596,6 +1624,36 @@ class TestCharm(unittest.TestCase):
 
         mock_add_s3_config.assert_called_once_with(expected_credentials)
 
+    @patch("controlsocket.ControlSocketClient.add_s3_config")
+    def test_s3_relation_credentials_replayed_without_optional_config(
+        self, mock_add_s3_config
+    ):
+        harness = self.harness
+
+        relation_id = harness.add_relation("s3-backend", "s3-integrator")
+        harness.add_relation_unit(relation_id, "s3-integrator/0")
+
+        harness.update_relation_data(
+            relation_id,
+            "s3-integrator",
+            {
+                "access-key": "ak",
+                "secret-key": "sk",
+            },
+        )
+
+        harness.set_leader(True)
+
+        mock_add_s3_config.assert_called_once_with(
+            {
+                "access_key": "ak",
+                "secret_key": "sk",
+                "bucket": None,
+                "region": None,
+                "endpoint": None,
+            }
+        )
+
     @patch(
         "controlsocket.ControlSocketClient.add_s3_config",
         side_effect=RuntimeError("boom"),
@@ -1617,7 +1675,7 @@ class TestCharm(unittest.TestCase):
         with patch.object(harness.charm, "api_port", return_value=17070):
             harness.evaluate_status()
         self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
-        self.assertIn("failed to reapply s3 credentials", harness.charm.unit.status.message)
+        self.assertIn("failed to reapply s3 config", harness.charm.unit.status.message)
 
     @patch("controlsocket.ControlSocketClient.add_s3_config")
     def test_s3_relation_credentials_updated(self, mock_add_s3_config):
@@ -1744,7 +1802,7 @@ class TestCharm(unittest.TestCase):
         with patch.object(harness.charm, "api_port", return_value=17070):
             harness.evaluate_status()
         self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
-        self.assertIn("failed to remove s3 credentials", harness.charm.unit.status.message)
+        self.assertIn("failed to remove s3 config", harness.charm.unit.status.message)
 
     @patch("controlsocket.ControlSocketClient.set_loki_endpoint")
     def test_loki_push_api_endpoint_joined(self, mock_set_loki_endpoint):

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1450,8 +1450,8 @@ class TestCharm(unittest.TestCase):
         harness.evaluate_status()
         self.assertIsInstance(harness.charm.unit.status, ActiveStatus)
 
-    @patch("controlsocket.ControlSocketClient.add_s3_credentials")
-    def test_s3_relation_credentials_changed(self, mock_add_s3_credentials):
+    @patch("controlsocket.ControlSocketClient.add_s3_config")
+    def test_s3_relation_credentials_changed(self, mock_add_s3_config):
         harness = self.harness
         harness.set_leader(True)
         harness.charm._stored.tracing_status_error = None
@@ -1467,6 +1467,7 @@ class TestCharm(unittest.TestCase):
                 "access-key": "ak",
                 "secret-key": "sk",
                 "bucket": "test-bucket",
+                "region": "us-east-1",
                 "endpoint": "https://s3.example",
             },
         )
@@ -1474,15 +1475,17 @@ class TestCharm(unittest.TestCase):
         expected_credentials = {
             "access_key": "ak",
             "secret_key": "sk",
+            "bucket": "test-bucket",
+            "region": "us-east-1",
             "endpoint": "https://s3.example",
         }
-        mock_add_s3_credentials.assert_called_once_with(expected_credentials)
+        mock_add_s3_config.assert_called_once_with(expected_credentials)
         with patch.object(harness.charm, "api_port", return_value=17070):
             harness.evaluate_status()
         self.assertIsInstance(harness.charm.unit.status, MaintenanceStatus)
 
-    @patch("controlsocket.ControlSocketClient.add_s3_credentials")
-    def test_s3_status_pending_clears_after_collect(self, mock_add_s3_credentials):
+    @patch("controlsocket.ControlSocketClient.add_s3_config")
+    def test_s3_status_pending_clears_after_collect(self, mock_add_s3_config):
         harness = self.harness
         harness.set_leader(True)
         harness.charm._stored.tracing_status_error = None
@@ -1494,10 +1497,21 @@ class TestCharm(unittest.TestCase):
         harness.update_relation_data(
             relation_id,
             "s3-integrator",
-            {"access-key": "ak", "secret-key": "sk", "bucket": "test-bucket"},
+            {
+                "access-key": "ak",
+                "secret-key": "sk",
+                "bucket": "test-bucket",
+                "region": "us-east-1",
+            },
         )
-        mock_add_s3_credentials.assert_called_once_with(
-            {"access_key": "ak", "secret_key": "sk", "endpoint": None}
+        mock_add_s3_config.assert_called_once_with(
+            {
+                "access_key": "ak",
+                "secret_key": "sk",
+                "bucket": "test-bucket",
+                "region": "us-east-1",
+                "endpoint": None,
+            }
         )
 
         with patch.object(harness.charm, "api_port", return_value=17070):
@@ -1509,7 +1523,7 @@ class TestCharm(unittest.TestCase):
         self.assertIsInstance(harness.charm.unit.status, ActiveStatus)
 
     @patch(
-        "controlsocket.ControlSocketClient.add_s3_credentials",
+        "controlsocket.ControlSocketClient.add_s3_config",
         side_effect=RuntimeError("boom"),
     )
     def test_s3_relation_credentials_changed_failure_sets_blocked(self, _mock_add):
@@ -1535,8 +1549,8 @@ class TestCharm(unittest.TestCase):
             harness.charm.unit.status.message,
         )
 
-    @patch("controlsocket.ControlSocketClient.add_s3_credentials")
-    def test_s3_relation_credentials_changed_non_leader_no_set(self, mock_add_s3_credentials):
+    @patch("controlsocket.ControlSocketClient.add_s3_config")
+    def test_s3_relation_credentials_changed_non_leader_no_set(self, mock_add_s3_config):
         harness = self.harness
         harness.set_leader(False)
 
@@ -1549,10 +1563,10 @@ class TestCharm(unittest.TestCase):
             {"access-key": "ak", "secret-key": "sk", "bucket": "test-bucket"},
         )
 
-        mock_add_s3_credentials.assert_not_called()
+        mock_add_s3_config.assert_not_called()
 
-    @patch("controlsocket.ControlSocketClient.add_s3_credentials")
-    def test_s3_relation_credentials_replayed_on_leader_elected(self, mock_add_s3_credentials):
+    @patch("controlsocket.ControlSocketClient.add_s3_config")
+    def test_s3_relation_credentials_replayed_on_leader_elected(self, mock_add_s3_config):
         harness = self.harness
 
         relation_id = harness.add_relation("s3-backend", "s3-integrator")
@@ -1565,22 +1579,25 @@ class TestCharm(unittest.TestCase):
                 "access-key": "ak",
                 "secret-key": "sk",
                 "bucket": "test-bucket",
+                "region": "us-east-1",
                 "endpoint": "https://s3.example",
             },
         )
         expected_credentials = {
             "access_key": "ak",
             "secret_key": "sk",
+            "bucket": "test-bucket",
+            "region": "us-east-1",
             "endpoint": "https://s3.example",
         }
-        mock_add_s3_credentials.assert_not_called()
+        mock_add_s3_config.assert_not_called()
 
         harness.set_leader(True)
 
-        mock_add_s3_credentials.assert_called_once_with(expected_credentials)
+        mock_add_s3_config.assert_called_once_with(expected_credentials)
 
     @patch(
-        "controlsocket.ControlSocketClient.add_s3_credentials",
+        "controlsocket.ControlSocketClient.add_s3_config",
         side_effect=RuntimeError("boom"),
     )
     def test_s3_relation_replay_failure_sets_blocked_status(self, _mock_add):
@@ -1602,8 +1619,8 @@ class TestCharm(unittest.TestCase):
         self.assertIsInstance(harness.charm.unit.status, BlockedStatus)
         self.assertIn("failed to reapply s3 credentials", harness.charm.unit.status.message)
 
-    @patch("controlsocket.ControlSocketClient.add_s3_credentials")
-    def test_s3_relation_credentials_updated(self, mock_add_s3_credentials):
+    @patch("controlsocket.ControlSocketClient.add_s3_config")
+    def test_s3_relation_credentials_updated(self, mock_add_s3_config):
         harness = self.harness
         harness.set_leader(True)
         harness.charm._stored.tracing_status_error = None
@@ -1615,16 +1632,32 @@ class TestCharm(unittest.TestCase):
         harness.update_relation_data(
             relation_id,
             "s3-integrator",
-            {"access-key": "ak", "secret-key": "sk", "bucket": "test-bucket"},
+            {
+                "access-key": "ak",
+                "secret-key": "sk",
+                "bucket": "test-bucket",
+                "region": "us-east-1",
+            },
         )
 
         harness.update_relation_data(
             relation_id,
             "s3-integrator",
-            {"access-key": "ak2", "secret-key": "sk2", "bucket": "test-bucket"},
+            {
+                "access-key": "ak2",
+                "secret-key": "sk2",
+                "bucket": "test-bucket",
+                "region": "us-west-2",
+            },
         )
-        mock_add_s3_credentials.assert_called_with(
-            {"access_key": "ak2", "secret_key": "sk2", "endpoint": None}
+        mock_add_s3_config.assert_called_with(
+            {
+                "access_key": "ak2",
+                "secret_key": "sk2",
+                "bucket": "test-bucket",
+                "region": "us-west-2",
+                "endpoint": None,
+            }
         )
         with patch.object(harness.charm, "api_port", return_value=17070):
             harness.evaluate_status()
@@ -1641,10 +1674,10 @@ class TestCharm(unittest.TestCase):
         data = harness.get_relation_data(relation_id, harness.charm.app.name)
         self.assertEqual(data["bucket"], f"relation-{relation_id}")
 
-    @patch("controlsocket.ControlSocketClient.remove_s3_credentials")
-    @patch("controlsocket.ControlSocketClient.add_s3_credentials")
+    @patch("controlsocket.ControlSocketClient.remove_s3_config")
+    @patch("controlsocket.ControlSocketClient.add_s3_config")
     def test_s3_relation_credentials_gone(
-        self, mock_add_s3_credentials, mock_remove_s3_credentials
+        self, mock_add_s3_config, mock_remove_s3_config
     ):
         harness = self.harness
         harness.set_leader(True)
@@ -1659,13 +1692,19 @@ class TestCharm(unittest.TestCase):
         )
 
         harness.remove_relation(relation_id)
-        mock_add_s3_credentials.assert_called_once_with(
-            {"access_key": "ak", "secret_key": "sk", "endpoint": None}
+        mock_add_s3_config.assert_called_once_with(
+            {
+                "access_key": "ak",
+                "secret_key": "sk",
+                "bucket": None,
+                "region": None,
+                "endpoint": None,
+            }
         )
-        mock_remove_s3_credentials.assert_called_once_with()
+        mock_remove_s3_config.assert_called_once_with()
 
-    @patch("controlsocket.ControlSocketClient.remove_s3_credentials")
-    def test_s3_relation_credentials_gone_non_leader(self, mock_remove_s3_credentials):
+    @patch("controlsocket.ControlSocketClient.remove_s3_config")
+    def test_s3_relation_credentials_gone_non_leader(self, mock_remove_s3_config):
         harness = self.harness
         harness.set_leader(False)
 
@@ -1679,10 +1718,10 @@ class TestCharm(unittest.TestCase):
         )
         harness.remove_relation(relation_id)
 
-        mock_remove_s3_credentials.assert_not_called()
+        mock_remove_s3_config.assert_not_called()
 
     @patch(
-        "controlsocket.ControlSocketClient.remove_s3_credentials",
+        "controlsocket.ControlSocketClient.remove_s3_config",
         side_effect=RuntimeError("boom"),
     )
     def test_s3_relation_credentials_gone_failure_sets_blocked(self, _mock_remove):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -145,6 +145,52 @@ class TestClass(unittest.TestCase):
             insecure_skip_verify=True,
         )
 
+    def test_add_s3_config_success(self):
+        mock_opener = MockOpener(self)
+        control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
+
+        mock_opener.expect(
+            url='http://localhost/s3-credentials',
+            method='POST',
+            body=(
+                r'{"access_key": "ak", '
+                r'"secret_key": "sk", '
+                r'"bucket": "test-bucket", '
+                r'"region": "us-east-1", '
+                r'"endpoint": "https://s3.example"}'
+            ),
+            response=MockResponse(
+                headers=MockHeaders(content_type='application/json'),
+                body=r'{"message":"updated s3 config"}'
+            )
+        )
+
+        control_socket.add_s3_config(
+            {
+                'access_key': 'ak',
+                'secret_key': 'sk',
+                'bucket': 'test-bucket',
+                'region': 'us-east-1',
+                'endpoint': 'https://s3.example',
+            }
+        )
+
+    def test_remove_s3_config_success(self):
+        mock_opener = MockOpener(self)
+        control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
+
+        mock_opener.expect(
+            url='http://localhost/s3-credentials',
+            method='DELETE',
+            body=None,
+            response=MockResponse(
+                headers=MockHeaders(content_type='application/json'),
+                body=r'{"message":"removed s3 config"}'
+            )
+        )
+
+        control_socket.remove_s3_config()
+
     def test_set_loki_endpoint_success(self):
         mock_opener = MockOpener(self)
         control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -150,7 +150,7 @@ class TestClass(unittest.TestCase):
         control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
 
         mock_opener.expect(
-            url='http://localhost/s3-credentials',
+            url='http://localhost/s3-config',
             method='POST',
             body=(
                 r'{"access_key": "ak", '
@@ -175,12 +175,49 @@ class TestClass(unittest.TestCase):
             }
         )
 
+    def test_add_s3_config_fail(self):
+        mock_opener = MockOpener(self)
+        control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
+
+        mock_opener.expect(
+            url='http://localhost/s3-config',
+            method='POST',
+            body=(
+                r'{"access_key": "ak", '
+                r'"secret_key": "sk", '
+                r'"bucket": "test-bucket", '
+                r'"region": "us-east-1", '
+                r'"endpoint": "https://s3.example"}'
+            ),
+            error=urllib.error.HTTPError(
+                url='http://localhost/s3-config',
+                code=500,
+                msg='',
+                hdrs=None,
+                fp=io.BytesIO(br'{"error":"failed to update s3 config"}'),
+            )
+        )
+
+        with self.assertRaises(APIError) as cm:
+            control_socket.add_s3_config(
+                {
+                    'access_key': 'ak',
+                    'secret_key': 'sk',
+                    'bucket': 'test-bucket',
+                    'region': 'us-east-1',
+                    'endpoint': 'https://s3.example',
+                }
+            )
+        self.assertEqual(cm.exception.body, {'error': 'failed to update s3 config'})
+        self.assertEqual(cm.exception.code, 500)
+        self.assertEqual(cm.exception.message, 'failed to update s3 config')
+
     def test_remove_s3_config_success(self):
         mock_opener = MockOpener(self)
         control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
 
         mock_opener.expect(
-            url='http://localhost/s3-credentials',
+            url='http://localhost/s3-config',
             method='DELETE',
             body=None,
             response=MockResponse(
@@ -190,6 +227,29 @@ class TestClass(unittest.TestCase):
         )
 
         control_socket.remove_s3_config()
+
+    def test_remove_s3_config_fail(self):
+        mock_opener = MockOpener(self)
+        control_socket = ControlSocketClient('fake_socket_path', opener=mock_opener)
+
+        mock_opener.expect(
+            url='http://localhost/s3-config',
+            method='DELETE',
+            body=None,
+            error=urllib.error.HTTPError(
+                url='http://localhost/s3-config',
+                code=404,
+                msg='',
+                hdrs=None,
+                fp=io.BytesIO(br'{"error":"s3 config not found"}'),
+            )
+        )
+
+        with self.assertRaises(APIError) as cm:
+            control_socket.remove_s3_config()
+        self.assertEqual(cm.exception.body, {'error': 's3 config not found'})
+        self.assertEqual(cm.exception.code, 404)
+        self.assertEqual(cm.exception.message, 's3 config not found')
 
     def test_set_loki_endpoint_success(self):
         mock_opener = MockOpener(self)


### PR DESCRIPTION
We require the bucket and region for the s3 integration if we're going to use the integration correctly. We can no longer guarantee that we'll have full access to the underlying s3 storage. If that's the case we need to play nicely with the integration.

The juju code isn't quite aligned to this yet, but it will be.