### PR TITLE
chore: merge 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 venv
 /.idea/
 /.vscode/
+/src/juju_controller.egg-info/

--- a/src/charm.py
+++ b/src/charm.py
@@ -3,6 +3,7 @@
 # Licensed under the GPLv3, see LICENSE file for details.
 
 import controlsocket
+import json
 import logging
 import secrets
 import urllib.parse
@@ -15,12 +16,17 @@ logger = logging.getLogger(__name__)
 
 
 class JujuControllerCharm(ops.CharmBase):
+    METRICS_USERNAME_KEY = "metrics-username"
+    METRICS_PASSWORD_KEY = "metrics-password"
+
     _stored = ops.StoredState()
 
     def __init__(self, *args):
         super().__init__(*args)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.start, self._on_start)
+        self.framework.observe(self.on.leader_elected, self._on_metrics_reconcile)
+        self.framework.observe(self.on.upgrade_charm, self._on_metrics_reconcile)
         self.framework.observe(
             self.on.dashboard_relation_joined, self._on_dashboard_relation_joined)
         self.framework.observe(
@@ -31,7 +37,10 @@ class JujuControllerCharm(ops.CharmBase):
         self.framework.observe(
             self.on.metrics_endpoint_relation_created, self._on_metrics_endpoint_relation_created)
         self.framework.observe(
+            self.on.metrics_endpoint_relation_changed, self._on_metrics_reconcile)
+        self.framework.observe(
             self.on.metrics_endpoint_relation_broken, self._on_metrics_endpoint_relation_broken)
+        self._metrics_endpoint = None
 
     def _on_start(self, _):
         self.unit.status = ops.ActiveStatus()
@@ -71,44 +80,141 @@ class JujuControllerCharm(ops.CharmBase):
                     'port': str(port)
                 })
 
-    def _on_metrics_endpoint_relation_created(self, event: ops.RelationJoinedEvent):
-        username = metrics_username(event.relation)
-        password = generate_password()
-        self.control_socket.add_metrics_user(username, password)
+    def _metrics_credentials(self, relations):
+        for relation in relations:
+            data = relation.data[self.app]
+            username = data.get(self.METRICS_USERNAME_KEY)
+            password = data.get(self.METRICS_PASSWORD_KEY)
+            if username and password:
+                return username, password
 
-        # Set up Prometheus scrape config
+            try:
+                jobs = json.loads(data.get("scrape_jobs", "[]"))
+                basic_auth = jobs[0]["basic_auth"]
+                username = basic_auth["username"]
+                # Use removeprefix once Python 3.8 support is dropped.
+                if username.startswith("user-"):
+                    username = username[len("user-"):]
+                return username, basic_auth["password"]
+            except (IndexError, KeyError, TypeError, ValueError):
+                continue
+        return None
+
+    def _metrics_jobs(self, username, password):
         try:
             api_port = self.api_port()
         except AgentConfException as e:
             self.unit.status = ops.BlockedStatus(
                 f"can't read controller API port from agent.conf: {e}")
+            return None
+        return [{
+            "metrics_path": "/introspection/metrics",
+            "scheme": "https",
+            "static_configs": [{"targets": [f"*:{api_port}"]}],
+            "basic_auth": {
+                "username": f"user-{username}",
+                "password": password,
+            },
+            "tls_config": {
+                "ca_file": self.ca_cert(),
+                "server_name": "juju-apiserver",
+            },
+        }]
+
+    def _configure_metrics_endpoint(self, username, password):
+        jobs = self._metrics_jobs(username, password)
+        if jobs is None:
+            return
+        if self._metrics_endpoint is None:
+            self._metrics_endpoint = MetricsEndpointProvider(self, jobs=jobs)
+            self._metrics_endpoint.set_scrape_job_spec()
+        else:
+            self._metrics_endpoint.update_scrape_job_spec(jobs)
+
+    def _configure_metrics_as_unit(self):
+        if self._metrics_endpoint is None:
+            self._metrics_endpoint = MetricsEndpointProvider(self, jobs=[])
+        self._metrics_endpoint.set_scrape_job_spec()
+
+    def _remove_metrics_user(self, username):
+        try:
+            self.control_socket.remove_metrics_user(username)
+        except controlsocket.APIError as e:
+            if e.code != 404:
+                raise
+
+    def _ensure_metrics_user(self, username, password):
+        try:
+            self.control_socket.add_metrics_user(username, password)
+        except controlsocket.APIError as e:
+            if e.code != 409:
+                raise
+            self._remove_metrics_user(username)
+            self.control_socket.add_metrics_user(username, password)
+
+    def _reconcile_metrics_as_leader(self, relations):
+        credentials = self._metrics_credentials(relations)
+        if credentials is None:
+            # MetricsEndpointProvider publishes one scrape job to every
+            # metrics-endpoint relation, so all Prometheus applications share
+            # one controller user. The oldest relation only seeds its name.
+            username = metrics_username(min(relations, key=lambda r: r.id))
+            password = generate_password()
+        else:
+            username, password = credentials
+
+        for relation in relations:
+            relation.data[self.app].update({
+                self.METRICS_USERNAME_KEY: username,
+                self.METRICS_PASSWORD_KEY: password,
+            })
+        self._ensure_metrics_user(username, password)
+        for relation in relations:
+            old_username = metrics_username(relation)
+            if old_username != username:
+                self._remove_metrics_user(old_username)
+        self._configure_metrics_endpoint(username, password)
+
+    def _reconcile_metrics(self, relations):
+        if not relations:
+            return False
+        if self.unit.is_leader():
+            self._reconcile_metrics_as_leader(relations)
+        else:
+            self._configure_metrics_as_unit()
+        return True
+
+    def _on_metrics_endpoint_relation_created(self, event):
+        relations = self.model.relations["metrics-endpoint"]
+        if not self._reconcile_metrics(relations):
+            event.defer()
+
+    def _on_metrics_reconcile(self, _event):
+        self._reconcile_metrics(self.model.relations["metrics-endpoint"])
+
+    def _on_metrics_endpoint_relation_broken(self, event):
+        relations = [
+            relation for relation in self.model.relations["metrics-endpoint"]
+            if relation.id != event.relation.id
+        ]
+        credentials = self._metrics_credentials(
+            [event.relation] + relations
+        )
+        if relations:
+            self._reconcile_metrics(relations)
+            if self.unit.is_leader() and credentials:
+                old_username = metrics_username(event.relation)
+                if old_username != credentials[0]:
+                    self._remove_metrics_user(old_username)
             return
 
-        metrics_endpoint = MetricsEndpointProvider(
-            self,
-            jobs=[{
-                "metrics_path": "/introspection/metrics",
-                "scheme": "https",
-                "static_configs": [{
-                    "targets": [
-                        f'*:{api_port}'
-                    ]
-                }],
-                "basic_auth": {
-                    "username": f'user-{username}',
-                    "password": password,
-                },
-                "tls_config": {
-                    "ca_file": self.ca_cert(),
-                    "server_name": "juju-apiserver",
-                },
-            }],
-        )
-        metrics_endpoint.set_scrape_job_spec()
-
-    def _on_metrics_endpoint_relation_broken(self, event: ops.RelationDepartedEvent):
-        username = metrics_username(event.relation)
-        self.control_socket.remove_metrics_user(username)
+        if not self.unit.is_leader():
+            return
+        usernames = {metrics_username(event.relation)}
+        if credentials:
+            usernames.add(credentials[0])
+        for username in usernames:
+            self._remove_metrics_user(username)
 
     def _agent_conf(self, key: str):
         """Read a value (by key) from the agent.conf file on disk."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,7 +17,7 @@ from charms.certificate_transfer_interface.v1.certificate_transfer import (
 )
 from ops.charm import CharmBase, CollectStatusEvent
 from ops.framework import StoredState
-from ops.charm import InstallEvent, RelationJoinedEvent, RelationDepartedEvent
+from ops.charm import InstallEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, Relation
 from pathlib import Path
@@ -27,6 +27,8 @@ logger = logging.getLogger(__name__)
 
 
 class JujuControllerCharm(CharmBase):
+    METRICS_USERNAME_KEY = "metrics-username"
+    METRICS_PASSWORD_KEY = "metrics-password"
     METRICS_SOCKET_PATH = '/var/lib/juju/control.socket'
     CONFIG_SOCKET_PATH = '/var/lib/juju/configchange.socket'
     DB_BIND_ADDR_KEY = 'db-bind-address'
@@ -67,12 +69,16 @@ class JujuControllerCharm(CharmBase):
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.leader_elected, self._on_metrics_reconcile)
+        self.framework.observe(self.on.upgrade_charm, self._on_metrics_reconcile)
         self.framework.observe(
             self.on.dashboard_relation_joined, self._on_dashboard_relation_joined)
         self.framework.observe(
             self.on.website_relation_joined, self._on_website_relation_joined)
         self.framework.observe(
             self.on.metrics_endpoint_relation_created, self._on_metrics_endpoint_relation_created)
+        self.framework.observe(
+            self.on.metrics_endpoint_relation_changed, self._on_metrics_reconcile)
         self.framework.observe(
             self.on.metrics_endpoint_relation_broken, self._on_metrics_endpoint_relation_broken)
         self.framework.observe(
@@ -89,6 +95,7 @@ class JujuControllerCharm(CharmBase):
         )
         self.framework.observe(
             self._certificate_transfer.on.certificates_removed, self._on_receive_ca_cert_removed)
+        self._metrics_endpoint = None
 
     def _on_install(self, event: InstallEvent):
         """Ensure that the controller configuration file exists."""
@@ -147,45 +154,142 @@ class JujuControllerCharm(CharmBase):
                     'port': str(port)
                 })
 
-    def _on_metrics_endpoint_relation_created(self, event: RelationJoinedEvent):
-        username = metrics_username(event.relation)
-        password = generate_password()
-        self._control_socket.add_metrics_user(username, password)
+    def _metrics_credentials(self, relations):
+        for relation in relations:
+            data = relation.data[self.app]
+            username = data.get(self.METRICS_USERNAME_KEY)
+            password = data.get(self.METRICS_PASSWORD_KEY)
+            if username and password:
+                return username, password
 
-        # Set up Prometheus scrape config
+            try:
+                jobs = json.loads(data.get("scrape_jobs", "[]"))
+                basic_auth = jobs[0]["basic_auth"]
+                username = basic_auth["username"]
+                # Use removeprefix once Python 3.8 support is dropped.
+                if username.startswith("user-"):
+                    username = username[len("user-"):]
+                return username, basic_auth["password"]
+            except (IndexError, KeyError, TypeError, ValueError):
+                continue
+        return None
+
+    def _metrics_jobs(self, username, password):
         try:
             api_port = self.api_port()
         except AgentConfException as e:
             self.unit.status = BlockedStatus(
                 f"can't read controller API port from agent.conf: {e}")
             logger.error('cannot read controller API port from agent configuration: %s', e)
+            return None
+        return [{
+            "metrics_path": "/introspection/metrics",
+            "scheme": "https",
+            "static_configs": [{"targets": [f"*:{api_port}"]}],
+            "basic_auth": {
+                "username": f"user-{username}",
+                "password": password,
+            },
+            "tls_config": {
+                "ca_file": self.ca_cert(),
+                "server_name": "juju-apiserver",
+            },
+        }]
+
+    def _configure_metrics_endpoint(self, username, password):
+        jobs = self._metrics_jobs(username, password)
+        if jobs is None:
+            return
+        if self._metrics_endpoint is None:
+            self._metrics_endpoint = MetricsEndpointProvider(self, jobs=jobs)
+            self._metrics_endpoint.set_scrape_job_spec()
+        else:
+            self._metrics_endpoint.update_scrape_job_spec(jobs)
+
+    def _configure_metrics_as_unit(self):
+        if self._metrics_endpoint is None:
+            self._metrics_endpoint = MetricsEndpointProvider(self, jobs=[])
+        self._metrics_endpoint.set_scrape_job_spec()
+
+    def _remove_metrics_user(self, username):
+        try:
+            self._control_socket.remove_metrics_user(username)
+        except controlsocket.APIError as e:
+            if e.code != 404:
+                raise
+
+    def _ensure_metrics_user(self, username, password):
+        try:
+            self._control_socket.add_metrics_user(username, password)
+        except controlsocket.APIError as e:
+            if e.code != 409:
+                raise
+            self._remove_metrics_user(username)
+            self._control_socket.add_metrics_user(username, password)
+
+    def _reconcile_metrics_as_leader(self, relations):
+        credentials = self._metrics_credentials(relations)
+        if credentials is None:
+            # MetricsEndpointProvider publishes one scrape job to every
+            # metrics-endpoint relation, so all Prometheus applications share
+            # one controller user. The oldest relation only seeds its name.
+            username = metrics_username(min(relations, key=lambda r: r.id))
+            password = generate_password()
+        else:
+            username, password = credentials
+
+        for relation in relations:
+            relation.data[self.app].update({
+                self.METRICS_USERNAME_KEY: username,
+                self.METRICS_PASSWORD_KEY: password,
+            })
+        self._ensure_metrics_user(username, password)
+        for relation in relations:
+            old_username = metrics_username(relation)
+            if old_username != username:
+                self._remove_metrics_user(old_username)
+        self._configure_metrics_endpoint(username, password)
+
+    def _reconcile_metrics(self, relations):
+        if not relations:
+            return False
+        if self.unit.is_leader():
+            self._reconcile_metrics_as_leader(relations)
+        else:
+            self._configure_metrics_as_unit()
+        return True
+
+    def _on_metrics_endpoint_relation_created(self, event):
+        relations = self.model.relations["metrics-endpoint"]
+        if not self._reconcile_metrics(relations):
+            event.defer()
+
+    def _on_metrics_reconcile(self, _event):
+        self._reconcile_metrics(self.model.relations["metrics-endpoint"])
+
+    def _on_metrics_endpoint_relation_broken(self, event):
+        relations = [
+            relation for relation in self.model.relations["metrics-endpoint"]
+            if relation.id != event.relation.id
+        ]
+        credentials = self._metrics_credentials(
+            [event.relation] + relations
+        )
+        if relations:
+            self._reconcile_metrics(relations)
+            if self.unit.is_leader() and credentials:
+                old_username = metrics_username(event.relation)
+                if old_username != credentials[0]:
+                    self._remove_metrics_user(old_username)
             return
 
-        metrics_endpoint = MetricsEndpointProvider(
-            self,
-            jobs=[{
-                "metrics_path": "/introspection/metrics",
-                "scheme": "https",
-                "static_configs": [{
-                    "targets": [
-                        f'*:{api_port}'
-                    ]
-                }],
-                "basic_auth": {
-                    "username": f'user-{username}',
-                    "password": password,
-                },
-                "tls_config": {
-                    "ca_file": self.ca_cert(),
-                    "server_name": "juju-apiserver",
-                },
-            }],
-        )
-        metrics_endpoint.set_scrape_job_spec()
-
-    def _on_metrics_endpoint_relation_broken(self, event: RelationDepartedEvent):
-        username = metrics_username(event.relation)
-        self._control_socket.remove_metrics_user(username)
+        if not self.unit.is_leader():
+            return
+        usernames = {metrics_username(event.relation)}
+        if credentials:
+            usernames.add(credentials[0])
+        for username in usernames:
+            self._remove_metrics_user(username)
 
     def _on_dbcluster_relation_changed(self, event):
         relation = event.relation

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -119,6 +119,7 @@ class TestCharm(unittest.TestCase):
     def test_metrics_endpoint_relation(self, mock_remove_user, mock_add_user,
                                        mock_metrics_provider, _):
         harness = self.harness
+        harness.set_leader(True)
         harness.add_network(address="192.168.1.17", endpoint="metrics-endpoint")
 
         relation_id = harness.add_relation('metrics-endpoint', 'prometheus-k8s')
@@ -144,6 +145,50 @@ class TestCharm(unittest.TestCase):
 
         harness.remove_relation(relation_id)
         mock_remove_user.assert_called_once_with(f'juju-metrics-r{relation_id}')
+
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    def test_metrics_endpoint_non_leader_only_sets_unit_data(
+            self, mock_add_user, mock_metrics_provider):
+        harness = self.harness
+        harness.add_relation("metrics-endpoint", "prometheus-k8s")
+
+        mock_add_user.assert_not_called()
+        mock_metrics_provider.assert_called_once_with(harness.charm, jobs=[])
+        mock_metrics_provider.return_value.set_scrape_job_spec.assert_called_once()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("charm.generate_password", new=lambda: "passwd")
+    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    @patch("controlsocket.ControlSocketClient.remove_metrics_user")
+    def test_metrics_relations_share_user(
+            self, mock_remove_user, mock_add_user, _mock_metrics_provider, _):
+        harness = self.harness
+        harness.set_leader(True)
+
+        first_id = harness.add_relation("metrics-endpoint", "prometheus-one")
+        second_id = harness.add_relation("metrics-endpoint", "prometheus-two")
+
+        # The provider publishes one scrape job to all relations, so separate
+        # Prometheus applications intentionally share one controller user.
+        username = f"juju-metrics-r{first_id}"
+        self.assertEqual(
+            harness.get_relation_data(second_id, "juju-controller"),
+            {"metrics-username": username, "metrics-password": "passwd"},
+        )
+        mock_add_user.assert_called_with(username, "passwd")
+        mock_remove_user.assert_any_call(f"juju-metrics-r{second_id}")
+
+        mock_remove_user.reset_mock()
+        harness.remove_relation(first_id)
+        self.assertNotIn(
+            username,
+            [call.args[0] for call in mock_remove_user.call_args_list],
+        )
+        mock_remove_user.reset_mock()
+        harness.remove_relation(second_id)
+        mock_remove_user.assert_any_call(username)
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
     @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
@@ -317,6 +362,7 @@ class TestCharm(unittest.TestCase):
     @patch("controlsocket.ControlSocketClient.add_metrics_user")
     def test_apiaddresses_missing_status(self, *_):
         harness = self.harness
+        harness.set_leader(True)
 
         harness.add_relation('metrics-endpoint', 'prometheus-k8s')
         harness.evaluate_status()

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -85,6 +85,7 @@ class TestCharm(unittest.TestCase):
         harness = Harness(JujuControllerCharm)
         self.addCleanup(harness.cleanup)
         harness.begin()
+        harness.set_leader(True)
 
         harness.add_network(address="192.168.1.17", endpoint="metrics-endpoint")
 
@@ -112,6 +113,55 @@ class TestCharm(unittest.TestCase):
         harness.remove_relation(relation_id)
         mock_remove_user.assert_called_once_with(f'juju-metrics-r{relation_id}')
 
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("controlsocket.Client.add_metrics_user")
+    def test_metrics_endpoint_non_leader_only_sets_unit_data(
+            self, mock_add_user, mock_metrics_provider):
+        harness = Harness(JujuControllerCharm)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+
+        harness.add_relation("metrics-endpoint", "prometheus-k8s")
+
+        mock_add_user.assert_not_called()
+        mock_metrics_provider.assert_called_once_with(harness.charm, jobs=[])
+        mock_metrics_provider.return_value.set_scrape_job_spec.assert_called_once()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("charm.generate_password", new=lambda: "passwd")
+    @patch("controlsocket.Client.add_metrics_user")
+    @patch("controlsocket.Client.remove_metrics_user")
+    def test_metrics_relations_share_user(
+            self, mock_remove_user, mock_add_user, _mock_metrics_provider, _):
+        harness = Harness(JujuControllerCharm)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.set_leader(True)
+
+        first_id = harness.add_relation("metrics-endpoint", "prometheus-one")
+        second_id = harness.add_relation("metrics-endpoint", "prometheus-two")
+
+        # The provider publishes one scrape job to all relations, so separate
+        # Prometheus applications intentionally share one controller user.
+        username = f"juju-metrics-r{first_id}"
+        self.assertEqual(
+            harness.get_relation_data(second_id, "juju-controller"),
+            {"metrics-username": username, "metrics-password": "passwd"},
+        )
+        mock_add_user.assert_called_with(username, "passwd")
+        mock_remove_user.assert_any_call(f"juju-metrics-r{second_id}")
+
+        mock_remove_user.reset_mock()
+        harness.remove_relation(first_id)
+        self.assertNotIn(
+            username,
+            [call.args[0] for call in mock_remove_user.call_args_list],
+        )
+        mock_remove_user.reset_mock()
+        harness.remove_relation(second_id)
+        mock_remove_user.assert_any_call(username)
+
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf_apiaddresses_missing)
     def test_apiaddresses_missing(self, _):
         harness = Harness(JujuControllerCharm)
@@ -138,6 +188,7 @@ class TestCharm(unittest.TestCase):
         harness = Harness(JujuControllerCharm)
         self.addCleanup(harness.cleanup)
         harness.begin()
+        harness.set_leader(True)
 
         harness.add_relation('metrics-endpoint', 'prometheus-k8s')
         self.assertEqual(harness.charm.unit.status, BlockedStatus(


### PR DESCRIPTION
Adds https://github.com/juju/juju-controller/pull/127 which fixes an issue in HA relating to a prometheus scrape endpoint.

Have only the application leader create and reconcile one controller metrics user shared by all Prometheus relations, while non-leaders publish only their unit addresses. Persist the credential in relation data so retries, leadership changes, and upgrades reuse the same identity, and clean it up after the final relation is removed.