### PR TITLE
fix: handle metrics-endpoint binding and APIError on k8s

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,6 @@ import configchangesocket
 import json
 import logging
 import secrets
-import unixsocket
 import urllib.parse
 import yaml
 
@@ -227,14 +226,14 @@ class JujuControllerCharm(CharmBase):
     def _remove_metrics_user(self, username):
         try:
             self._control_socket.remove_metrics_user(username)
-        except unixsocket.APIError as e:
+        except controlsocket.APIError as e:
             if e.code != 404:
                 raise
 
     def _ensure_metrics_user(self, username, password):
         try:
             self._control_socket.add_metrics_user(username, password)
-        except unixsocket.APIError as e:
+        except controlsocket.APIError as e:
             if e.code not in (409, 500):
                 raise
             self._remove_metrics_user(username)

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,6 +7,7 @@ import configchangesocket
 import json
 import logging
 import secrets
+import unixsocket
 import urllib.parse
 import yaml
 
@@ -202,29 +203,39 @@ class JujuControllerCharm(CharmBase):
         jobs = self._metrics_jobs(username, password)
         if jobs is None:
             return
-        if self._metrics_endpoint is None:
-            self._metrics_endpoint = MetricsEndpointProvider(self, jobs=jobs)
-            self._metrics_endpoint.set_scrape_job_spec()
-        else:
-            self._metrics_endpoint.update_scrape_job_spec(jobs)
+        try:
+            if self._metrics_endpoint is None:
+                self._metrics_endpoint = MetricsEndpointProvider(self, jobs=jobs)
+                self._metrics_endpoint.set_scrape_job_spec()
+            else:
+                self._metrics_endpoint.update_scrape_job_spec(jobs)
+        except ValueError as e:
+            logger.warning(
+                "metrics-endpoint binding not IP-resolvable yet; will retry: %s", e)
+            raise BindingPendingException() from e
 
     def _configure_metrics_as_unit(self):
         if self._metrics_endpoint is None:
             self._metrics_endpoint = MetricsEndpointProvider(self, jobs=[])
-        self._metrics_endpoint.set_scrape_job_spec()
+        try:
+            self._metrics_endpoint.set_scrape_job_spec()
+        except ValueError as e:
+            logger.warning(
+                "metrics-endpoint binding not IP-resolvable yet (unit); will retry: %s", e)
+            raise BindingPendingException() from e
 
     def _remove_metrics_user(self, username):
         try:
             self._control_socket.remove_metrics_user(username)
-        except controlsocket.APIError as e:
+        except unixsocket.APIError as e:
             if e.code != 404:
                 raise
 
     def _ensure_metrics_user(self, username, password):
         try:
             self._control_socket.add_metrics_user(username, password)
-        except controlsocket.APIError as e:
-            if e.code != 409:
+        except unixsocket.APIError as e:
+            if e.code not in (409, 500):
                 raise
             self._remove_metrics_user(username)
             self._control_socket.add_metrics_user(username, password)
@@ -255,10 +266,13 @@ class JujuControllerCharm(CharmBase):
     def _reconcile_metrics(self, relations):
         if not relations:
             return False
-        if self.unit.is_leader():
-            self._reconcile_metrics_as_leader(relations)
-        else:
-            self._configure_metrics_as_unit()
+        try:
+            if self.unit.is_leader():
+                self._reconcile_metrics_as_leader(relations)
+            else:
+                self._configure_metrics_as_unit()
+        except BindingPendingException:
+            return False
         return True
 
     def _on_metrics_endpoint_relation_created(self, event):
@@ -493,6 +507,10 @@ class ControllerProcessException(Exception):
 
 class DBBindAddressException(Exception):
     """Raised when there are errors regarding the database bind addresses"""
+
+
+class BindingPendingException(Exception):
+    """Raised when the relation network binding is not yet IP-resolvable."""
 
 
 if __name__ == "__main__":

--- a/src/controlsocket.py
+++ b/src/controlsocket.py
@@ -5,6 +5,7 @@ import urllib
 from typing import Optional
 
 import unixsocket
+from unixsocket import APIError  # noqa: F401, re-exported for charm.py
 import logging
 
 logger = logging.getLogger(__name__)

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -21,7 +21,8 @@ from charm import JujuControllerCharm, AgentConfException
 from ops.model import BlockedStatus, ActiveStatus
 from ops.testing import Harness
 from unittest.mock import Mock, mock_open, patch
-from unixsocket import APIError, ConnectionError as SocketConnectionError
+from controlsocket import APIError
+from unixsocket import ConnectionError as SocketConnectionError
 
 agent_conf = '''
 apiaddresses:

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -21,7 +21,7 @@ from charm import JujuControllerCharm, AgentConfException
 from ops.model import BlockedStatus, ActiveStatus
 from ops.testing import Harness
 from unittest.mock import Mock, mock_open, patch
-from unixsocket import ConnectionError as SocketConnectionError
+from unixsocket import APIError, ConnectionError as SocketConnectionError
 
 agent_conf = '''
 apiaddresses:
@@ -189,6 +189,131 @@ class TestCharm(unittest.TestCase):
         mock_remove_user.reset_mock()
         harness.remove_relation(second_id)
         mock_remove_user.assert_any_call(username)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("charm.generate_password", new=lambda: "passwd")
+    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    def test_metrics_endpoint_binding_unresolved_defers_and_retries(
+            self, mock_add_user, mock_metrics_provider, _):
+        harness = self.harness
+        harness.set_leader(True)
+
+        mock_provider_instance = mock_metrics_provider.return_value
+        mock_provider_instance.set_scrape_job_spec.side_effect = ValueError(
+            "'controller-0.controller-service-endpoints.controller-ctrl-xyz.svc.cluster.local' "
+            "does not appear to be an IPv4 or IPv6 network"
+        )
+
+        relation_id = harness.add_relation('metrics-endpoint', 'prometheus-k8s')
+        mock_add_user.assert_called_once_with(f'juju-metrics-r{relation_id}', 'passwd')
+        self.assertIn(
+            f"juju-metrics-r{relation_id}",
+            harness.get_relation_data(relation_id, "juju-controller")["metrics-username"],
+        )
+
+        notices = [n[0] for n in harness.framework._storage.notices("")]
+        self.assertTrue(
+            any("metrics_endpoint_relation_created" in n for n in notices)
+        )
+
+        mock_provider_instance.update_scrape_job_spec.side_effect = None
+        harness.charm._on_metrics_reconcile(None)
+        mock_provider_instance.update_scrape_job_spec.assert_called_once()
+
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    def test_metrics_endpoint_non_leader_binding_unresolved_defers(
+            self, mock_metrics_provider):
+        harness = self.harness
+        mock_provider_instance = mock_metrics_provider.return_value
+        mock_provider_instance.set_scrape_job_spec.side_effect = ValueError(
+            "'controller-0.controller-service-endpoints.controller-ctrl-xyz.svc.cluster.local' "
+            "does not appear to be an IPv4 or IPv6 network"
+        )
+
+        harness.add_relation("metrics-endpoint", "prometheus-k8s")
+
+        notices = [n[0] for n in harness.framework._storage.notices("")]
+        self.assertTrue(
+            any("metrics_endpoint_relation_created" in n for n in notices)
+        )
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("charm.generate_password", new=lambda: "passwd")
+    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    def test_metrics_endpoint_update_scrape_job_spec_binding_unresolved(
+            self, mock_add_user, mock_metrics_provider, _):
+        harness = self.harness
+        harness.set_leader(True)
+
+        mock_provider_instance = mock_metrics_provider.return_value
+        harness.add_relation('metrics-endpoint', 'prometheus-k8s')
+        mock_provider_instance.set_scrape_job_spec.assert_called_once()
+
+        mock_provider_instance.update_scrape_job_spec.side_effect = ValueError(
+            "not an IPv4 or IPv6 network"
+        )
+        harness.charm._on_metrics_reconcile(None)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("charm.generate_password", new=lambda: "passwd")
+    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    @patch("controlsocket.ControlSocketClient.remove_metrics_user")
+    def test_metrics_ensure_user_recovers_from_409(
+            self, mock_remove_user, mock_add_user, mock_metrics_provider, _):
+        harness = self.harness
+        harness.set_leader(True)
+
+        mock_add_user.side_effect = [
+            APIError({}, 409, "Conflict", "user already exists"),
+            None,
+        ]
+
+        relation_id = harness.add_relation('metrics-endpoint', 'prometheus-k8s')
+        mock_remove_user.assert_called_once_with(f'juju-metrics-r{relation_id}')
+        self.assertEqual(mock_add_user.call_count, 2)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("charm.generate_password", new=lambda: "passwd")
+    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    @patch("controlsocket.ControlSocketClient.remove_metrics_user")
+    def test_metrics_ensure_user_recovers_from_500(
+            self, mock_remove_user, mock_add_user, mock_metrics_provider, _):
+        harness = self.harness
+        harness.set_leader(True)
+
+        mock_add_user.side_effect = [
+            APIError({}, 500, "Internal Server Error",
+                     'retrieving existing user "juju-metrics-r1": password destroyed'),
+            None,
+        ]
+
+        relation_id = harness.add_relation('metrics-endpoint', 'prometheus-k8s')
+        mock_remove_user.assert_called_once_with(f'juju-metrics-r{relation_id}')
+        self.assertEqual(mock_add_user.call_count, 2)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("charm.generate_password", new=lambda: "passwd")
+    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    @patch("controlsocket.ControlSocketClient.remove_metrics_user")
+    def test_metrics_remove_user_ignores_404(
+            self, mock_remove_user, mock_add_user, mock_metrics_provider, _):
+        harness = self.harness
+        harness.set_leader(True)
+
+        mock_remove_user.side_effect = APIError({}, 404, "Not Found", "not found")
+        mock_add_user.side_effect = [
+            APIError({}, 409, "Conflict", "user already exists"),
+            None,
+        ]
+
+        relation_id = harness.add_relation('metrics-endpoint', 'prometheus-k8s')
+        mock_remove_user.assert_called_once_with(f'juju-metrics-r{relation_id}')
+        self.assertEqual(mock_add_user.call_count, 2)
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
     @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -256,6 +256,7 @@ class TestCharm(unittest.TestCase):
             "not an IPv4 or IPv6 network"
         )
         harness.charm._on_metrics_reconcile(None)
+        mock_provider_instance.update_scrape_job_spec.assert_called_once()
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
     @patch("charm.MetricsEndpointProvider", autospec=True)

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -316,6 +316,46 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(mock_add_user.call_count, 2)
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("charm.generate_password", new=lambda: "passwd")
+    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    @patch("controlsocket.ControlSocketClient.remove_metrics_user")
+    def test_metrics_ensure_user_reraises_non_recoverable_error(
+            self, mock_remove_user, mock_add_user, mock_metrics_provider, _):
+        harness = self.harness
+        harness.set_leader(True)
+
+        mock_add_user.side_effect = APIError(
+            {}, 403, "Forbidden", "forbidden")
+
+        with self.assertRaises(APIError):
+            harness.add_relation('metrics-endpoint', 'prometheus-k8s')
+
+        mock_remove_user.assert_not_called()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("charm.generate_password", new=lambda: "passwd")
+    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    @patch("controlsocket.ControlSocketClient.remove_metrics_user")
+    def test_metrics_remove_user_reraises_non_404_error(
+            self, mock_remove_user, mock_add_user, mock_metrics_provider, _):
+        harness = self.harness
+        harness.set_leader(True)
+
+        mock_add_user.side_effect = [
+            APIError({}, 409, "Conflict", "user already exists"),
+            None,
+        ]
+        mock_remove_user.side_effect = APIError(
+            {}, 500, "Internal Server Error", "server error")
+
+        with self.assertRaises(APIError):
+            harness.add_relation('metrics-endpoint', 'prometheus-k8s')
+
+        mock_remove_user.assert_called_once()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
     @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
     def test_tracing_relation_updates_endpoints(self, mock_set_tracing_config, *_):
         harness = self.harness

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -358,6 +358,90 @@ class TestCharm(unittest.TestCase):
         mock_remove_user.assert_called_once()
 
     @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("charm.generate_password", new=lambda: "passwd")
+    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    @patch("controlsocket.ControlSocketClient.remove_metrics_user")
+    def test_metrics_ensure_user_retry_failure_propagates(
+            self, mock_remove_user, mock_add_user, mock_metrics_provider, _):
+        harness = self.harness
+        harness.set_leader(True)
+
+        mock_add_user.side_effect = [
+            APIError({}, 500, "Internal Server Error", "password destroyed"),
+            APIError({}, 500, "Internal Server Error", "password destroyed"),
+        ]
+
+        with self.assertRaises(APIError):
+            harness.add_relation('metrics-endpoint', 'prometheus-k8s')
+
+        self.assertEqual(mock_add_user.call_count, 2)
+        mock_remove_user.assert_called_once()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("charm.generate_password", new=lambda: "passwd")
+    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    def test_metrics_endpoint_redefers_until_resolved(
+            self, mock_add_user, mock_metrics_provider, _):
+        harness = self.harness
+        harness.set_leader(True)
+
+        mock_provider_instance = mock_metrics_provider.return_value
+        mock_provider_instance.set_scrape_job_spec.side_effect = ValueError(
+            "not an IPv4 or IPv6 network"
+        )
+        mock_provider_instance.update_scrape_job_spec.side_effect = ValueError(
+            "not an IPv4 or IPv6 network"
+        )
+
+        harness.add_relation('metrics-endpoint', 'prometheus-k8s')
+
+        notices = [n[0] for n in harness.framework._storage.notices("")]
+        self.assertTrue(
+            any("metrics_endpoint_relation_created" in n for n in notices)
+        )
+
+        mock_provider_instance.update_scrape_job_spec.side_effect = None
+        harness.charm._on_metrics_reconcile(None)
+        mock_provider_instance.update_scrape_job_spec.assert_called_once()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
+    @patch("charm.MetricsEndpointProvider", autospec=True)
+    @patch("charm.generate_password")
+    @patch("controlsocket.ControlSocketClient.add_metrics_user")
+    def test_metrics_endpoint_password_stable_across_deferred_retry(
+            self, mock_add_user, mock_generate_password,
+            mock_metrics_provider, _):
+        harness = self.harness
+        harness.set_leader(True)
+
+        mock_generate_password.return_value = "first-pass"
+
+        mock_provider_instance = mock_metrics_provider.return_value
+        mock_provider_instance.set_scrape_job_spec.side_effect = ValueError(
+            "not an IPv4 or IPv6 network"
+        )
+
+        relation_id = harness.add_relation('metrics-endpoint', 'prometheus-k8s')
+
+        self.assertEqual(
+            harness.get_relation_data(relation_id, "juju-controller")["metrics-password"],
+            "first-pass",
+        )
+
+        mock_provider_instance.update_scrape_job_spec.side_effect = None
+        mock_generate_password.return_value = "second-pass"
+        harness.charm._on_metrics_reconcile(None)
+
+        self.assertEqual(
+            harness.get_relation_data(relation_id, "juju-controller")["metrics-password"],
+            "first-pass",
+        )
+        for call in mock_add_user.call_args_list:
+            self.assertEqual(call.args[1], "first-pass")
+
+    @patch("builtins.open", new_callable=mock_open, read_data=agent_conf)
     @patch("controlsocket.ControlSocketClient.set_charm_tracing_config")
     def test_tracing_relation_updates_endpoints(self, mock_set_tracing_config, *_):
         harness = self.harness

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -10,6 +10,12 @@ from configchangesocket import ConfigChangeSocketClient
 from unixsocket import APIError, ConnectionError
 
 
+class TestAPIErrorReexport(unittest.TestCase):
+    def test_controlsocket_reexports_api_error(self):
+        from controlsocket import APIError as CSAPIError
+        assert CSAPIError is APIError
+
+
 class TestClass(unittest.TestCase):
     def test_add_metrics_user_success(self):
         mock_opener = MockOpener(self)


### PR DESCRIPTION
## Description

Fixes #130, Fixes #112. Related to #93.
JIRA: [JUJU-10266](https://warthogs.atlassian.net/browse/JUJU-10266)

Fixes three issues affecting the `metrics-endpoint` relation hooks on k8s and HA controllers:

1. **`controlsocket.APIError` was never imported (Fixes #112):**
   The charm caught `controlsocket.APIError`, but `APIError` lives in `unixsocket.py`. Any socket error (e.g., user already exists, not found) crashed the hook with `AttributeError: module 'controlsocket' has no attribute 'APIError'`.

2. **`_ensure_metrics_user` recovery (Fixes #112):**
   The charm only handled HTTP 409; the Juju controller returns HTTP 500 (`password destroyed`) when `AddUser` consumes and zeroes the password buffer before checking `UserAlreadyExists`. The charm now catches both 409 and 500, removes the stale user, and recreates it cleanly.

3. **K8s service FQDN bind_address handling (Fixes #130, Related to #93):**
   On k8s, `network-get` can return a service FQDN instead of an IP for `bind_address` early in the unit lifecycle. The `prometheus_scrape` library calls `ipaddress.ip_network()` on this value, raising `ValueError`. The charm now catches this, logs a warning, and defers the event so it retries when the binding resolves to a valid IP.

## Fly-by fixes

- **`controlsocket.APIError` re-export:** Added `from unixsocket import APIError` to `controlsocket.py` so the existing `except controlsocket.APIError` in `charm.py` actually works. The charm now uses `controlsocket.APIError` consistently rather than importing `unixsocket` directly, keeping `controlsocket` as the public interface.
- **Test coverage additions:** Added negative-path tests for the error-whitelist re-raise branches (`_ensure_metrics_user` non-(409,500), `_remove_metrics_user` non-404), recovery retry failure propagation, repeated deferral until binding resolves, credential stability across deferred retry, and `controlsocket.APIError` re-export identity.

## Related Juju PR

The Juju-side fix for the `password destroyed` root cause is in **[juju/juju PR #23143](https://github.com/juju/juju/pull/23143)**.

## QA steps

**End-to-end validation with companion PR:**

1. Bootstrap a controller on microk8s with the agent built from [juju/juju PR #23143](https://github.com/juju/juju/pull/23143).
2. On the deployed controller, copy `src/controlsocket.py` and `src/charm.py` from this PR.
3. Run the reproduce steps from [juju/juju-controller #130](https://github.com/juju/juju-controller/issues/130):
   ```bash
   juju offer controller.controller:metrics-endpoint
   juju deploy prometheus-k8s --channel 1/stable --trust
   juju relate prometheus-k8s admin/controller.controller
   ```
4. **Verify:** The controller SAAS stays `active` after ~5 s (not `error`), and `check_prometheus_targets` passes without retry timeout.

## Testing

- `./run_tests` — 43 unit tests pass (including error recovery for 409, 500, and 404, negative-path re-raise, retry failure propagation, repeated deferral, credential stability, and re-export identity).
- `flake8` — clean.
- CI `microk8s` integration leg is the canonical signal.

[JUJU-10266]: https://warthogs.atlassian.net/browse/JUJU-10266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ