### PR TITLE
chore: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security policy
+
+## Supported versions
+
+Security updates will be released for versions corresponding to
+[Juju's versions that receive security updates](https://canonical.com/juju/docs/juju-cli/latest/releasenotes/).
+
+## Reporting a vulnerability
+
+Please provide a description of the issue, the steps you took to
+create the issue, affected versions, and, if known, mitigations for
+the issue.
+
+The preferred way to report a security issue is through
+[GitHub's security advisory for this project](https://github.com/juju/juju-controller/security/advisories/new). See
+[Privately reporting a security
+vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+for instructions on reporting using GitHub's security advisory feature.
+
+The [Ubuntu Security disclosure and embargo
+policy](https://ubuntu.com/security/disclosure-policy) contains more
+information about how can contact us, what you can expect when you contact us,
+and what we expect from you.


### PR DESCRIPTION
A part of #134. This PR added `SECURITY.md` and targeted the `main` branch.

The `https://github.com/juju/juju-controller/security/advisories/new` link returns 404 at the moment. I assume it is because this repo doesn't enable [private vulnerabilities report](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configure-for-a-repository) yet.